### PR TITLE
Wkhtmltopdf download fix

### DIFF
--- a/clouder_template_odoo/clouder_template_odoo_data.xml
+++ b/clouder_template_odoo/clouder_template_odoo_data.xml
@@ -59,7 +59,7 @@ RUN echo "deb http://http.debian.net/debian wheezy-backports main" >> /etc/apt/s
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y -qq install python-dateutil python-feedparser python-gdata python-ldap python-libxslt1 python-lxml python-mako python-openid python-passlib python-psycopg2 python-pybabel python-pychart python-pydot python-pyparsing python-reportlab python-simplejson python-tz python-vatnumber python-vobject python-webdav python-werkzeug python-xlwt python-yaml python-zsi python-decorator python-unittest2 python-psutil python-requests python-jinja2 python-pypdf python-docutils python-paramiko postgresql-client libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils libjpeg8
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq install python-pip
 
-RUN wget http://downloads.sourceforge.net/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-wheezy-amd64.deb -O /tmp/wkhtmltox.deb
+RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-wheezy-amd64.deb -O /tmp/wkhtmltox.deb
 RUN dpkg -i /tmp/wkhtmltox.deb
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``


### PR DESCRIPTION
Correct URL. Changed to download.gna.org