### PR TITLE
Update clouder_template_backup_data.xml

### DIFF
--- a/clouder/clouder_template_backup/clouder_template_backup_data.xml
+++ b/clouder/clouder_template_backup/clouder_template_backup_data.xml
@@ -140,7 +140,7 @@ RUN apt-get update
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install python2.7-dev python-fuse python-pyxattr python-pylibacl python-tornado linux-libc-dev acl attr par2 git make cron ncftp g++
 
-RUN git clone git://github.com/bup/bup /opt/bup
+RUN git clone https://github.com/bup/bup.git /opt/bup
 RUN make -C /opt/bup
 RUN make install -C /opt/bup
 


### PR DESCRIPTION
I had this problem while building the backup image

stderr : The command '/bin/sh -c git clone git://github.com/bup/bup /opt/bup' returned a non-zero code: 128

I changed the link with the one in bup/bup git and started working just fine. I dont know if i'm the only one who had this issue. can you check this out Yannick?