### PR TITLE
Bind template options bugfix

### DIFF
--- a/clouder_template_bind/template.py
+++ b/clouder_template_bind/template.py
@@ -61,7 +61,7 @@ class ClouderDomain(models.Model):
             self.dns_id.execute(['echo "type master;" >> /etc/bind/named.conf'])
 
             # Configure this only if the option is set
-            if self.dns_id.options['slave_ip']:
+            if self.dns_id.options['slave_ip']['value']:
                 self.dns_id.execute([
                     'echo "allow-transfer { '+
                     self.dns_id.options['slave_ip']['value'] + ';};" '


### PR DESCRIPTION
Fixing an error made when adding a condition for slave_ip option: the previous fix verified if the value existed instead of if it was filled.