### PR TITLE
[IMP][9.0] mqt: Add support for MQT builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: python
+sudo: false
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+python:
+  - "2.7"
+
+addons:
+  apt:
+
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml
+      - python-simplejson
+      - python-serial
+      - python-yaml
+
+env:
+  global:
+  - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+
+  matrix:
+  - LINT_CHECK="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
+
+virtualenv:
+  system_site_packages: true
+
+install:
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - travis_install_nightly
+
+script:
+  - travis_run_tests
+
+after_success:
+  - travis_after_tests_success

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+connector

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+erppeek
+paramiko


### PR DESCRIPTION
This PR adds support for MQT builds. They are currently failing right now, but first step to 🍏  is 🔴 .

* https://travis-ci.org/laslabs/clouder/builds/166779604
* https://runbot.laslabs.io/runbot/build/5488

I'll be submitting subsequent PRs to fix the builds on a per-module basis, unless you would instead prefer one large one.

Changelog for this commit:

* Add travis file
* Add requirements.txt
* Add oca_dependencies.txt