### PR TITLE
[WIP][FIX] Fix build errors for Clouder 0.9.0

### DIFF
--- a/clouder/application.py
+++ b/clouder/application.py
@@ -188,8 +188,19 @@ class ClouderApplication(models.Model):
     required = fields.Boolean('Required?')
     sequence = fields.Integer('Sequence')
     child_ids = fields.Many2many(
-        'clouder.application', 'clouder_application_parent_child_rel',
-        'parent_id', 'child_id', 'Childs')
+        'clouder.application',
+        'clouder_application_parent_child_rel',
+        'parent_ids',
+        'child_ids',
+        'Children',
+    )
+    parent_ids = fields.Many2many(
+        'clouder.application',
+        'clouder_application_parent_child_rel',
+        'child_ids',
+        'parent_ids',
+        'Parents',
+    )
     container_ids = fields.One2many('clouder.container', 'application_id',
                                     'Containers')
     update_strategy = fields.Selection([

--- a/clouder_runner_openshift/template.xml
+++ b/clouder_runner_openshift/template.xml
@@ -10,9 +10,11 @@
 
         <record id="image_openshift" model="clouder.image">
             <field name="name">img_openshift</field>
-            <field name="current_version">1</field>
-            <field name="privileged">True</field>
             <field name="parent_from">openshift/origin</field>
+        </record>
+        <record id="image_version_openshift" model="clouder.image.version">
+            <field name="name">1</field>
+            <field name="image_id" ref="image_openshift" />
         </record>
         <record id="image_openshift_volume_rootfs" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
@@ -60,9 +62,6 @@
             <field name="expose">internet</field>
         </record>
 
-
-
-
         <record id="application_openshift" model="clouder.application">
             <field name="name">openshift</field>
             <field name="code">openshift</field>
@@ -70,12 +69,8 @@
             <field name="type_id" ref="application_type_openshift"/>
             <field name="default_image_id" ref="image_openshift"/>
             <field name="container_time_between_save">9999</field>
-            <field name="container_saverepo_change">30</field>
-            <field name="container_saverepo_expiration">90</field>
             <field name="container_save_expiration">5</field>
             <field name="base_time_between_save">9999</field>
-            <field name="base_saverepo_change">30</field>
-            <field name="base_saverepo_expiration">90</field>
             <field name="base_save_expiration">5</field>
         </record>
 

--- a/clouder_template_magento/__openerp__.py
+++ b/clouder_template_magento/__openerp__.py
@@ -29,7 +29,8 @@
         'clouder_template_shinken',
         'clouder_template_postfix',
         'clouder_template_proxy',
-        'clouder_template_mysql'
+        'clouder_template_mysql',
+        'clouder_template_piwik',
     ],
     'author': 'Yannick Buron (Clouder)',
     'license': 'Other OSI approved licence',

--- a/clouder_template_magento/template.xml
+++ b/clouder_template_magento/template.xml
@@ -116,10 +116,13 @@
         <record id="image_magento_data" model="clouder.image">
             <field name="name">img_magento_data</field>
             <field name="type_id" ref="application_type_magento"/>
-            <field name="current_version">8.0</field>
             <field name="parent_from">clouder/clouder-magento-data</field>
             <field name="parent_id"/>
             <field name="dockerfile"/>
+        </record>
+        <record id="image_version_magento_data" model="clouder.image.version">
+            <field name="name">8.0</field>
+            <field name="image_id" ref="image_magento_data" />
         </record>
         <record id="image_magento_data_volume_logs" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
@@ -167,25 +170,21 @@
         </record>
         <record id="image_magento_exec_volume_logs" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
-            <field name="from_code">data</field>
             <field name="name">/opt/magento/exec/var/log</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_config" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
-            <field name="from_code">data</field>
             <field name="name">/opt/magento/exec/app/etc</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_local_modules" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
-            <field name="from_code">data</field>
             <field name="name">/opt/magento/exec/app/code/local</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_sites_enabled" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
-            <field name="from_code">data</field>
             <field name="name">/etc/apache2/sites-enabled</field>
             <field name="nosave" eval="True"/>
         </record>
@@ -248,7 +247,6 @@
             <field name="required" eval="True"/>
             <field name="auto" eval="True"/>
             <field name="make_link" eval="True"/>
-            <field name="service" eval="True"/>
         </record>
         <record id="application_magento_link_postfix" model="clouder.application.link">
             <field name="application_id" ref="application_magento"/>
@@ -275,7 +273,7 @@
             <field name="name">Magento Data</field>
             <field name="code">data</field>
             <field name="type_id" ref="application_type_magento"/>
-            <field name="parent_id" ref="application_magento"/>
+            <field name="parent_ids" eval="[(4, ref('application_magento'))]"/>
             <field name="default_image_id" ref="image_magento_data"/>
             <field name="sequence">1</field>
             <field name="required" eval="True"/>


### PR DESCRIPTION
This is a work in progress. 

@YannickB would you mind verifying that I inferred these fixes correctly? It's going to be pretty much the same thing across all of the templates, so I want to make sure I'm doing it right before moving further.

High level of the inferences represented in this PR:
* `clouder.image.current_version` is no longer a static char, but instead a relation to `clouder.image.version`, in which the `name` field should be the string that was previously defined
* `clouder.image.privileged` logic has been removed with no replacement
* `clouder.application.*_saverepo_*` logic has been removed with no replacement
* `clouder.image.volume.from_code` logic has been removed with no replacement
* `clouder.application.link.service` logic has been remved with no replacement
* `clouder.application.parent_id` was removed erroneously & needed to be added back (child_ids m2m relation still had parent_id set as the relation col). 
 * Column naming of `parent_id` needed to be updated to conform to m2m standard of `_ids` prefix on multi relations.
* Magento is dependent on Piwik