### PR TITLE
[IMP] clouder: Error handling

### DIFF
--- a/clouder/__openerp__.py
+++ b/clouder/__openerp__.py
@@ -25,7 +25,7 @@
     'version': '9.0.0.0.0',
     'category': 'Clouder',
     'depends': ['base', 'connector'],
-    'author': 'Yannick Buron (Clouder)',
+    'author': 'Yannick Buron (Clouder), LasLabs',
     'license': 'Other OSI approved licence',
     'website': 'https://github.com/clouder-community/clouder',
     'demo': [],

--- a/clouder/application.py
+++ b/clouder/application.py
@@ -21,8 +21,7 @@
 ##############################################################################
 
 
-from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
+from openerp import models, fields, api
 from datetime import datetime
 import re
 
@@ -80,11 +79,11 @@ class ClouderApplicationType(models.Model):
         Check that the application type name does not contain any forbidden
         characters.
         """
-        if not re.match(r"^[\w\d-]*$", self.name) \
-                or not re.match(r"^[\w\d-]*$", self.system_user):
-            raise except_orm(_('Data error!'), _(
-                "Name and system_user can only contains letters, "
-                "digits and -")
+        if not all([re.match(r"^[\w\d-]*$", self.name),
+                    re.match(r"^[\w\d-]*$", self.system_user)]):
+            self.raise_error(
+                "Name and system_user can only contain letters, "
+                "digits and -"
             )
 
 
@@ -301,17 +300,20 @@ class ClouderApplication(models.Model):
         """
 
         if not re.match(r"^[\w\d-]*$", self.code) or len(self.code) > 20:
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Code can only contains letters, digits and "
-                "- and shall be less than 20 characters"))
+                "- and shall be less than 20 characters"
+            )
         if self.admin_name and not re.match(r"^[\w\d_]*$", self.admin_name):
-            raise except_orm(_('Data error!'), _(
-                "Admin name can only contains letters, digits and underscore"))
+            self.raise_error(
+                "Admin name can only contains letters, digits and underscore"
+            )
         if self.admin_email \
                 and not re.match(r"^[\w\d_@.-]*$", self.admin_email):
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Admin email can only contains letters, "
-                "digits, underscore, - and @"))
+                "digits, underscore, - and @"
+            )
 
     @api.multi
     @api.constrains('default_image_id', 'child_ids')
@@ -319,7 +321,7 @@ class ClouderApplication(models.Model):
         """
         """
         if not self.default_image_id and not self.child_ids:
-            raise self.raise_error('You need to specify the image!')
+            self.raise_error('You need to specify the image!')
 
     @api.multi
     @api.onchange('type_id')
@@ -374,8 +376,9 @@ class ClouderApplication(models.Model):
         :param vals: The values to update
         """
         if 'code' in vals and vals['code'] != self.code:
-            raise except_orm(_('Data error!'), _(
-                "It's too dangerous to modify the application code!"))
+            self.raise_error(
+                "It's too dangerous to modify the application code!"
+            )
         res = super(ClouderApplication, self).write(vals)
         if 'template_id' in vals:
             self = self.browse(self.id)
@@ -484,16 +487,14 @@ class ClouderApplicationMetadata(models.Model):
         for metadata in self:
             if metadata.is_function:
                 if not metadata.func_name:
-                    raise except_orm(
-                        _('Data error!'),
-                        _("You must enter the function name "
-                          "to set is_function to true.")
+                    self.raise_error(
+                        "You must enter the function name "
+                        "to set is_function to true."
                     )
                 else:
                     obj_env = self.env['clouder.'+self.clouder_type]
                     if not getattr(obj_env, self.func_name, False):
-                        raise except_orm(
-                            _('Base Metadata error!'),
-                            _("Invalid function name {0} for clouder.base".
-                              format(self.name.func_name))
+                        self.raise_error(
+                            "Invalid function name %s for clouder.base",
+                            self.name.func_name,
                         )

--- a/clouder/base.py
+++ b/clouder/base.py
@@ -20,8 +20,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
+from openerp import models, fields, api
 import re
 
 from datetime import datetime, timedelta
@@ -62,8 +61,9 @@ class ClouderDomain(models.Model):
         characters.
         """
         if not re.match(r"^[\w\d.-]*$", self.name):
-            raise except_orm(_('Data error!'), _(
-                "Name can only contains letters, digits - and dot"))
+            self.raise_error(
+                "Name can only contains letters, digits - and dot"
+            )
 
     @api.multi
     def write(self, vals):
@@ -241,21 +241,25 @@ class ClouderBase(models.Model):
         forbidden characters.
         """
         if not re.match(r"^[\w\d-]*$", self.name):
-            raise except_orm(_('Data error!'), _(
-                "Name can only contains letters, digits and -"))
+            self.raise_error(
+                "Name can only contains letters, digits and -",
+            )
         if not re.match(r"^[\w\d_.@-]*$", self.admin_name):
-            raise except_orm(_('Data error!'), _(
-                "Admin name can only contains letters, digits and underscore"))
+            self.raise_error(
+                "Admin name can only contains letters, digits and underscore",
+            )
         if self.admin_email\
                 and not re.match(r"^[\w\d_.@-]*$", self.admin_email):
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Admin email can only contains letters, "
-                "digits, underscore, - and @"))
+                "digits, underscore, - and @"
+            )
         if self.poweruser_email \
                 and not re.match(r"^[\w\d_.@-]*$", self.poweruser_email):
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Poweruser email can only contains letters, "
-                "digits, underscore, - and @"))
+                "digits, underscore, - and @"
+            )
 
     @api.multi
     @api.constrains('container_id', 'application_id')
@@ -266,9 +270,10 @@ class ClouderBase(models.Model):
         """
         if self.application_id.id != \
                 self.container_id.application_id.id:
-            raise except_orm(_('Data error!'),
-                             _("The application of base must be the same "
-                               "than the application of the container."))
+            self.raise_error(
+                "The application of base must be the same "
+                "than the application of the container."
+            )
 
     @api.multi
     def onchange_application_id_vals(self, vals):
@@ -599,23 +604,28 @@ class ClouderBase(models.Model):
             domain_obj = self.env['clouder.domain']
             container_obj = self.env['clouder.container']
             if 'application_id' not in vals or not vals['application_id']:
-                raise except_orm(_('Error!'), _(
-                    "You need to specify the application of the base."))
+                self.raise_error(
+                    "You need to specify the application of the base."
+                )
             application = application_obj.browse(vals['application_id'])
             if not application.next_server_id:
-                raise except_orm(_('Error!'), _(
+                self.raise_error(
                     "You need to specify the next server in "
-                    "application for the container autocreate."))
+                    "application for the container autocreate."
+                )
             if not application.default_image_id.version_ids:
-                raise except_orm(_('Error!'), _(
+                self.raise_error(
                     "No version for the image linked to the application, "
-                    "abandoning container autocreate..."))
+                    "abandoning container autocreate..."
+                )
             if 'domain_id' not in vals or not vals['domain_id']:
-                raise except_orm(_('Error!'), _(
-                    "You need to specify the domain of the base."))
+                self.raise_error(
+                    "You need to specify the domain of the base."
+                )
             if 'environment_id' not in vals or not vals['environment_id']:
-                raise except_orm(_('Error!'), _(
-                    "You need to specify the environment of the base."))
+                self.raise_error(
+                    "You need to specify the environment of the base."
+                )
             domain = domain_obj.browse(vals['domain_id'])
             container_vals = {
                 'name': vals['name'] + '-' +
@@ -973,11 +983,10 @@ class ClouderBaseOption(models.Model):
         if this option is required.
         """
         if self.name.required and not self.value:
-            raise except_orm(
-                _('Data error!'),
-                _("You need to specify a value for the option " +
-                  self.name.name + " for the base " +
-                  self.base_id.name + ".")
+            self.raise_error(
+                'You need to specify a value for the option "%s" '
+                'for the base "%s".',
+                self.name.name, self.base_id.name,
             )
 
 
@@ -1015,11 +1024,9 @@ class ClouderBaseLink(models.Model):
         if this link is required.
         """
         if self.required and not self.target:
-            raise except_orm(
-                _('Data error!'),
-                _("You need to specify a link to " +
-                  self.name.name + " for the base " +
-                  self.base_id.name)
+            self.raise_error(
+                'You need to specify a link to "%s" for the base "%s"',
+                self.name.name, self.base_id.name,
             )
 
     @api.multi
@@ -1108,9 +1115,9 @@ class ClouderBaseChild(models.Model):
     @api.constrains('child_id')
     def _check_child_id(self):
         if self.child_id and not self.child_id.parent_id == self:
-            raise except_orm(
-                _('Data error!'),
-                _("The child container is not correctly linked to the parent"))
+            self.raise_error(
+                "The child container is not correctly linked to the parent",
+            )
 
     @api.multi
     def create_child(self):
@@ -1176,10 +1183,9 @@ class ClouderBaseMetadata(models.Model):
         """
         def _missing_function():
             # If the function is missing, raise an exception
-            raise except_orm(
-                _('Base Metadata error!'),
-                _("Invalid function name {0} for clouder.base".
-                  format(self.name.func_name))
+            self.raise_error(
+                'Invalid function name "%s" for "clouder.base".',
+                self.name.func_name,
             )
 
         # Computing the function if needed
@@ -1211,10 +1217,9 @@ class ClouderBaseMetadata(models.Model):
         Checks that the metadata is intended for containers
         """
         if self.name.clouder_type != 'base':
-            raise except_orm(
-                _('Base Metadata error!'),
-                _("This metadata is intended for {0} only.".
-                  format(self.name.clouder_type))
+            self.raise_error(
+                "This metadata is intended for %s only.",
+                self.name.clouder_type,
             )
 
     @api.multi
@@ -1230,8 +1235,7 @@ class ClouderBaseMetadata(models.Model):
             self.value
         except ValueError:
             # User display
-            raise except_orm(
-                _('Base Metadata error!'),
-                _("Invalid value for type {0}: \n\t'{1}'\n".
-                  format(self.name.value_type, self.value_data))
+            self.raise_error(
+                'Invalid value for type "%s": \n\t"%s"\n',
+                self.name.value_type, self.value_data,
             )

--- a/clouder/clouder_runner_docker/template.py
+++ b/clouder/clouder_runner_docker/template.py
@@ -20,8 +20,7 @@
 #
 ##############################################################################
 
-from openerp import models, api, _
-from openerp.exceptions import except_orm
+from openerp import models, api
 import re
 
 
@@ -70,9 +69,9 @@ class ClouderContainer(models.Model):
                         ports = option['value']
             if ports:
                 if not re.match(r"^[\d,-]*$", ports):
-                    raise except_orm(
-                        _('Data error!'),
-                        _("Ports can only contains digits, - and ,"))
+                    self.raise_error(
+                        "Ports can only contains digits, - and ,",
+                    )
 
                 for scope in ports.split(','):
                     if re.match(r"^[\d]*$", scope):

--- a/clouder/config.py
+++ b/clouder/config.py
@@ -20,8 +20,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
+from openerp import models, fields, api
 import re
 
 from datetime import datetime
@@ -82,9 +81,10 @@ class ClouderConfigSettings(models.Model):
         """
         if self.email_sysadmin \
                 and not re.match(r"^[\w\d_.@-]*$", self.email_sysadmin):
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Sysadmin email can only contains letters, "
-                "digits, underscore, - and @"))
+                "digits, underscore, - and @",
+            )
 
     @api.multi
     def save_all(self):

--- a/clouder/environment.py
+++ b/clouder/environment.py
@@ -20,8 +20,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
+from openerp import models, fields, api
 
 import re
 
@@ -61,14 +60,14 @@ class ClouderEnvironment(models.Model):
         when containers are linked to the environment
         """
         if self.prefix and not re.match(r"^[\w]*$", self.prefix):
-            raise except_orm(
-                _('Data error!'),
-                _("Prefix can only contains letters"))
+            self.raise_error(
+                "Prefix can only contains letters",
+            )
         if self.container_ids and not self.prefix:
-            raise except_orm(
-                _('Data error!'),
-                _("You cannot have an empty prefix when "
-                  "containers are linked"))
+            self.raise_error(
+                "You cannot have an empty prefix when "
+                "containers are linked",
+            )
 
     @api.multi
     def write(self, vals):
@@ -76,9 +75,9 @@ class ClouderEnvironment(models.Model):
         Removes the possibility to change the prefix if containers are linked
         """
         if 'prefix' in vals and self.container_ids:
-            raise except_orm(
-                _('Data error!'),
-                _("You cannot have an empty prefix "
-                  "when containers are linked"))
+            self.raise_error(
+                "You cannot have an empty prefix "
+                "when containers are linked",
+            )
 
         super(ClouderEnvironment, self).write(vals)

--- a/clouder/exceptions.py
+++ b/clouder/exceptions.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+
+from openerp.exceptions import ValidationError
+
+
+class ClouderError(ValidationError):
+    """ It provides an error containing Clouder specific logic
+
+    Attributes:
+        model_obj: (clouder.model.ClouderModel) Clouder model instance that
+            trigger this error
+    """
+
+    def __init__(self, model_obj, message):
+        """ It throws error, stores the model_obj for use, and issues log
+        :param model_obj: (clouder.model.ClouderModel) Clouder model object
+            that is triggering the exception
+        :param message: (str) Message to throw and log
+        :raises: (ClouderError) Exception after generating appropriate log
+        """
+        model_obj.log('Raising error: "%s"' % message)
+        model_obj.log('Version: "%s"' % model_obj.version)
+        self.model_obj = model_obj
+        super(ClouderError, self).__init__(message)

--- a/clouder/image.py
+++ b/clouder/image.py
@@ -22,7 +22,6 @@
 
 
 from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
 import re
 from datetime import datetime
 
@@ -87,8 +86,9 @@ class ClouderImage(models.Model):
         elif self.parent_from:
             dockerfile += self.parent_from
         else:
-            raise except_orm(_('Data error!'),
-                             _("You need to specify the image to inherit!"))
+            self.raise_error(
+                "You need to specify the image to inherit!",
+            )
 
         dockerfile += \
             '\nMAINTAINER ' + self.env['clouder.model'].email_sysadmin + '\n'
@@ -116,8 +116,9 @@ class ClouderImage(models.Model):
         characters.
         """
         if not re.match(r"^[\w\d_]*$", self.name):
-            raise except_orm(_('Data error!'), _(
-                "Name can only contains letters, digits and underscore"))
+            self.raise_error(
+                "Name can only contains letters, digits and underscore",
+            )
 
     @api.multi
     def build_image(
@@ -134,10 +135,10 @@ class ClouderImage(models.Model):
         """
 
         if not self.registry_id:
-            raise except_orm(
-                _('Date error!'),
-                _("You need to specify the registry "
-                  "where the version must be stored."))
+            self.raise_error(
+                "You need to specify the registry "
+                "where the version must be stored.",
+            )
         now = datetime.now()
         version = self.current_version + '.' + now.strftime('%Y%m%d.%H%M%S')
         self.env['clouder.image.version'].create({
@@ -311,9 +312,10 @@ class ClouderImageVersion(models.Model):
         characters.
         """
         if not re.match(r"^[\w\d_.]*$", self.name):
-            raise except_orm(_('Data error!'), _(
+            self.raise_error(
                 "Image version can only contains letters, "
-                "digits and underscore and dot"))
+                "digits and underscore and dot.",
+            )
 
     @api.multi
     def unlink(self):
@@ -322,15 +324,14 @@ class ClouderImageVersion(models.Model):
         some containers are linked to it.
         """
         if self.container_ids:
-            raise except_orm(
-                _('Inherit error!'),
+            self.raise_error(
                 _("A container is linked to this image version, "
                   "you can't delete it!"))
         if self.child_ids:
-            raise except_orm(
-                _('Inherit error!'),
-                _("A child is linked to this image version, "
-                  "you can't delete it!"))
+            self.raise_error(
+                "A child is linked to this image version, "
+                "you can't delete it!",
+            )
         return super(ClouderImageVersion, self).unlink()
 
     @api.multi

--- a/clouder/model.py
+++ b/clouder/model.py
@@ -20,28 +20,28 @@
 #
 ##############################################################################
 
+import copy_reg
+import errno
+import logging
+import os.path
+import random
+import re
+import requests
+import select
+import string
+import subprocess
+import time
+
+from datetime import datetime
+from os.path import expanduser
 
 from openerp import models, fields, api, _, tools, release
-from openerp.exceptions import except_orm
 from openerp.addons.connector.session import ConnectorSession
 from openerp.addons.connector.queue.job import\
     job, whitelist_unpickle_global
 
-from datetime import datetime
-import subprocess
-import os.path
-import string
-import copy_reg
-import errno
-import random
-import re
-import requests
-import time
-import select
+from openerp.addons.clouder.exceptions import ClouderError
 
-from os.path import expanduser
-
-import logging
 _logger = logging.getLogger(__name__)
 
 try:
@@ -72,9 +72,9 @@ def connector_enqueue(
     if priority:
         job.write({'priority': priority + 1})
         job.env.cr.commit()
-        raise except_orm(
-            _('Priority error!'),
-            _("Waiting for another job to finish"))
+        session.env[model_name].raise_error(
+            "Waiting for another job to finish",
+        )
 
     res = getattr(record, func_name)(action, job_id, *args, **kargs)
     # if 'clouder_unlink' in record.env.context:
@@ -237,9 +237,9 @@ class ClouderModel(models.AbstractModel):
         """
         if self._name != 'clouder.config.settings' and not \
                 self.env.ref('clouder.clouder_settings').email_sysadmin:
-            raise except_orm(
-                _('Data error!'),
-                _("You need to specify the sysadmin email in configuration"))
+            self.raise_error(
+                "You need to specify the sysadmin email in configuration.",
+            )
 
     @api.multi
     def check_priority(self):
@@ -277,15 +277,16 @@ class ClouderModel(models.AbstractModel):
                             message + '\n'
         self.env.cr.commit()
 
-    def raise_error(self, message):
-        self.log('Raising error :' + message)
-        self.log('Version :' + str(self.version))
-        if self.version >= 9:
-            from openerp.exceptions import UserError
-            raise UserError(message)
-        else:
-            # from openerp.exceptions import except_orm
-            raise except_orm(_(''), _(message))
+    def raise_error(self, message, interpolations):
+        """ Raises a ClouderError with a translated message
+        :param message: (str) Message including placeholders for string
+            interpolation. Interpolation takes place via the ``%`` operator.
+        :param interpolations: (dict|tuple) Mixed objects to be used for
+            string interpolation after message translation. Dict for named
+            parameters or tuple for positional. Cannot use both.
+        :raises: (clouder.exceptions.ClouderError)
+        """
+        raise ClouderError(self, _(message) % interpolations)
 
     @api.multi
     def do(self, name, action, where=False):
@@ -478,15 +479,16 @@ class ClouderModel(models.AbstractModel):
 
             if identityfile is None:
                 self.raise_error(
-                    "It seems Clouder have no record in the ssh config to "
-                    "connect to your server.\nMake sure there is a '" +
-                    self.name + ""
-                    "' record in the ~/.ssh/config of the Clouder "
-                    "system user.\n"
-                    "To easily add this record, depending if Clouder try to "
-                    "connect to a server or a container, you can click on the"
-                    " 'reinstall' button of the server record or 'reset key' "
-                    "button of the container record you try to access.")
+                    'Clouder does not have a record in the ssh config to '
+                    'connect to your server.\n'
+                    'Make sure there is a "%s" record in the "~/.ssh/config" '
+                    'of the Clouder system user.\n'
+                    'To easily add this record, you can click on the '
+                    '"Reinstall" button of the server record, or the '
+                    '"Reset Key" button of the container record you are '
+                    'trying to access',
+                    self.name
+                )
 
             # Security with latest version of Paramiko
             # https://github.com/clouder-community/clouder/issues/11
@@ -495,13 +497,13 @@ class ClouderModel(models.AbstractModel):
 
             # Probably not useful anymore, to remove later
             if not isinstance(identityfile, basestring):
-                raise except_orm(
-                    _('Data error!'),
-                    _("For unknown reason, it seems the variable identityfile "
-                      "in the connect ssh function is invalid. Please report "
-                      "this message.\n"
-                      "Identityfile : " + str(identityfile) +
-                      ", type : " + type(identityfile)))
+                self.raise_error(
+                    'For an unknown reason, the variable identityfile '
+                    'in the connect ssh function is invalid. Please report '
+                    'this message.\n'
+                    'IdentityFile: "%s", Type: "%s"',
+                    identityfile, type(identityfile),
+                )
 
             self.log('connect: ssh ' + (username and username + '@' or '') +
                      host + (port and ' -p ' + str(port) or ''))
@@ -511,16 +513,17 @@ class ClouderModel(models.AbstractModel):
                     host, port=int(port), username=username,
                     key_filename=os.path.expanduser(identityfile))
             except Exception as inst:
-                raise except_orm(
-                    _('Connect error!'),
-                    _("We were not able to connect to your server. Please "
-                      "make sure you add the public key in the "
-                      "authorized_keys file of your root user on your server."
-                      "\nIf you were trying to connect to a container, "
-                      "a click on the 'reset key' button on the container "
-                      "record may resolve the problem.\n"
-                      "Target : " + host + "\n"
-                      "Error : " + str(inst)))
+                self.raise_error(
+                    'We were not able to connect to your server. Please '
+                    'make sure you add the public key in the '
+                    'authorized_keys file of your root user on your server.\n'
+                    'If you were trying to connect to a container, '
+                    'a click on the "Reset Key" button on the container '
+                    'record may resolve the problem.\n'
+                    'Target: "%s" \n'
+                    'Error: "%s"',
+                    host, inst,
+                )
             ssh_connections[host_fullname] = ssh
         else:
             ssh = ssh_connections[host_fullname]

--- a/clouder/save.py
+++ b/clouder/save.py
@@ -21,8 +21,7 @@
 ##############################################################################
 
 
-from openerp import models, fields, api, _
-from openerp.exceptions import except_orm
+from openerp import models, fields, api
 
 from datetime import datetime
 import ast
@@ -441,41 +440,41 @@ class ClouderSave(models.Model):
         environments = environment_obj.search([
             ('prefix', '=', self.computed_restore_to_environment)])
         if not environments:
-                raise except_orm(
-                    _('Error!'),
-                    _("Couldn't find environment " +
-                      self.computed_restore_to_environment +
-                      ", aborting restoration."))
+                self.raise_error(
+                    'Could not find environment "%s". Aborting restoration.',
+                    self.computed_restore_to_environment,
+                )
         apps = application_obj.search([('code', '=', self.container_app)])
         if not apps:
-            raise except_orm(
-                _('Error!'),
-                _("Couldn't find application " + self.container_app +
-                  ", aborting restoration."))
+            self.raise_error(
+                'Could not find application "%s". Aborting restoration.',
+                self.container_app,
+            )
 
         if self.container_restore_to_suffix or not self.container_id:
 
             imgs = image_obj.search([('name', '=', self.container_img)])
             if not imgs:
-                raise except_orm(
-                    _('Error!'),
-                    _("Couldn't find image " + self.container_img +
-                      ", aborting restoration."))
+                self.raise_error(
+                    'Could not find the image "%s". Aborting restoration.',
+                    self.container_img,
+                )
 
             img_versions = image_version_obj.search(
                 [('name', '=', self.container_img_version)])
             # upgrade = True
             if not img_versions:
                 self.log(
-                    "Warning, couldn't find the image version, using latest")
+                    "Warning, could not find the image version, using latest")
                 # We do not want to force the upgrade if we had to use latest
                 # upgrade = False
                 versions = imgs[0].version_ids
                 if not versions:
-                    raise except_orm(
-                        _('Error!'),
-                        _("Couldn't find versions for image " +
-                          self.container_img + ", aborting restoration."))
+                    self.raise_error(
+                        'Could not find versions for image "%s". '
+                        'Aborting restoration.',
+                        self.container_img,
+                    )
                 img_versions = [versions[0]]
 
             containers = container_obj.search([
@@ -492,11 +491,10 @@ class ClouderSave(models.Model):
                 servers = server_obj.search([
                     ('name', '=', self.computed_container_restore_to_server)])
                 if not servers:
-                    raise except_orm(
-                        _('Error!'),
-                        _("Couldn't find server " +
-                          self.computed_container_restore_to_server +
-                          ", aborting restoration."))
+                    self.raise_error(
+                        'Could not find server "%s". Aborting restoration.',
+                        self.computed_container_restore_to_server,
+                    )
 
                 ports = []
                 for port, port_vals \
@@ -585,11 +583,11 @@ class ClouderSave(models.Model):
                     domains = domain_obj.search(
                         [('name', '=', self.computed_base_restore_to_domain)])
                     if not domains:
-                        raise except_orm(
-                            _('Error!'),
-                            _("Couldn't find domain " +
-                              self.computed_base_restore_to_domain +
-                              ", aborting restoration."))
+                        self.raise_error(
+                            'Could not find domain "%s". '
+                            'Aborting restoration.',
+                            self.computed_base_restore_to_domain,
+                        )
                     options = []
                     for option, option_vals in ast.literal_eval(
                             self.base_options).iteritems():


### PR DESCRIPTION
This PR centralizes error handling in `clouder` core module. Changelog:

* Create ClouderError base class
* Update `clouder.model.raise_error` to use new class
* Centralize all error handling to model method
* Fix translation on most errors - variables should not be translated
* Remove contractions from most errors

Some notes:
* This breaks existing translation on a lot of the errors -
 * There were variables transposed in with the translations, which creates duplicate translations - those were removed
 * IMO contractions should be avoided in technical writing - while I was breaking translations, I figured it would be worth updating those as well
 * Standardized use of `"` to encapsulate variable data, and somewhat standardized the punctuation

Thoughts:

* A lot of these error strings are being duplicated, and are somewhat inconsistent (eg the digits allowed error). It might be good to add some sort of centralized error strings to compensate, but I didn't have an immediate solution & this PR was already quite hefty. Another time, I believe.
