### PR TITLE
[IMP] clouder: Path and Environment Handling

### DIFF
--- a/clouder/__openerp__.py
+++ b/clouder/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'Clouder',
-    'version': '10.0.10.0.0',
+    'version': '9.0.2.0.0',
     'category': 'Clouder',
     'depends': ['base'],
     'author': 'Yannick Buron (Clouder), LasLabs',

--- a/clouder/__openerp__.py
+++ b/clouder/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'Clouder',
-    'version': '9.0.2.0.0',
+    'version': '9.0.10.0.0',
     'category': 'Clouder',
     'depends': ['base'],
     'author': 'Yannick Buron (Clouder), LasLabs',

--- a/clouder/application.py
+++ b/clouder/application.py
@@ -26,7 +26,7 @@ import re
 
 from openerp import models, fields, api
 
-from . import model
+from .model import generate_random_password
 
 
 class ClouderApplicationTag(models.Model):
@@ -120,9 +120,9 @@ class ClouderApplicationTypeOption(models.Model):
     def generate_default(self):
         res = ''
         if self.name == 'db_password':
-            res = model.generate_random_password(20)
+            res = generate_random_password(20)
         if self.name == 'secret':
-            res = model.generate_random_password(50)
+            res = generate_random_password(50)
         if self.name == 'ssh_privatekey':
             res = self.env['clouder.server']._default_private_key()
         if self.name == 'ssh_publickey':

--- a/clouder/base.py
+++ b/clouder/base.py
@@ -20,13 +20,16 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api
-import re
 
 from datetime import datetime, timedelta
-from . import model
-
 import logging
+import re
+
+from openerp import models, fields, api
+
+from .model import generate_random_password
+
+
 _logger = logging.getLogger(__name__)
 
 
@@ -101,13 +104,16 @@ class ClouderBase(models.Model):
         'clouder.container', 'Container', required=True)
     admin_name = fields.Char('Admin name', required=True)
     admin_password = fields.Char(
-        'Admin password', required=True,
-        default=model.generate_random_password(20))
+        'Admin password',
+        required=True,
+        default=lambda s: generate_random_password(20),
+    )
     admin_email = fields.Char('Admin email', required=True)
     poweruser_name = fields.Char('PowerUser name')
     poweruser_password = fields.Char(
         'PowerUser password',
-        default=model.generate_random_password(12))
+        default=lambda s: generate_random_password(12),
+    )
     poweruser_email = fields.Char('PowerUser email')
     build = fields.Selection(
         [('none', 'No action'), ('build', 'Build'), ('restore', 'Restore')],

--- a/clouder/config.py
+++ b/clouder/config.py
@@ -20,10 +20,11 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api
+from datetime import datetime
+import os.path
 import re
 
-from datetime import datetime
+from openerp import models, fields, api
 
 
 class ClouderConfigBackupMethod(models.Model):
@@ -72,6 +73,11 @@ class ClouderConfigSettings(models.Model):
         """
         return self.env['clouder.model'].now_hour_regular
 
+    @property
+    def settings_id(self):
+        """ It provides the Clouder settings record """
+        return self.env.ref('clouder.clouder_settings')
+
     @api.multi
     @api.constrains('email_sysadmin')
     def _check_email_sysadmin(self):
@@ -96,40 +102,57 @@ class ClouderConfigSettings(models.Model):
         Execute some maintenance on backup containers, and force a save
         on all containers and bases.
         """
-        self = self.with_context(save_comment='Save before upload_save')
 
-        backups = self.env['clouder.container'].search(
-            [('application_id.type_id.name', '=', 'backup')])
-        for backup in backups:
-            backup.execute(['export BUP_DIR=/opt/backup/bup;', 'bup', 'fsck',
-                            '-r'], username="backup")
-            # http://stackoverflow.com/questions/1904860/
-            #     how-to-remove-unreferenced-blobs-from-my-git-repo
-            # https://github.com/zoranzaric/bup/tree/tmp/gc/Documentation
-            # https://groups.google.com/forum/#!topic/bup-list/uvPifF_tUVs
-            backup.execute(['git', 'gc', '--prune=now'],
-                           path='/opt/backup/bup', username="backup")
-            backup.execute(['export BUP_DIR=/opt/backup/bup;', 'bup', 'fsck',
-                            '-g'], username="backup")
+        with self._private_env() as env:
+            self = self.with_env(env).with_context(
+                save_comment='Save before upload_save'
+            )
 
-        containers = self.env['clouder.container'].search(
-            [('autosave', '=', True)])
-        for container in containers:
-            container.save_exec()
+            backup_dir = os.path.join(self.BACKUP_DIR, 'bup')
 
-        bases = self.env['clouder.base'].search([('autosave', '=', True)])
-        for base in bases:
-            base.save_exec()
+            backups = self.env['clouder.container'].search(
+                [('application_id.type_id.name', '=', 'backup')])
+            for backup in backups:
+                backup.execute([
+                    'export BUP_DIR="%s";' % backup_dir,
+                    'bup', 'fsck', '-r',
+                ],
+                    username="backup",
+                )
+                # http://stackoverflow.com/questions/1904860/
+                #     how-to-remove-unreferenced-blobs-from-my-git-repo
+                # https://github.com/zoranzaric/bup/tree/tmp/gc/Documentation
+                # https://groups.google.com/forum/#!topic/bup-list/uvPifF_tUVs
+                backup.execute(
+                    ['git', 'gc', '--prune=now'],
+                    backup_dir,
+                    username="backup",
+                )
+                backup.execute([
+                    'export BUP_DIR="%s";' % backup_dir, 'bup', 'fsck', '-g',
+                ],
+                    username="backup",
+                )
 
-        links = self.env['clouder.container.link'].search(
-            [('container_id.application_id.type_id.name', '=', 'backup'),
-             ('name.code', '=', 'backup-upload')])
-        for link in links:
-            link.deploy_exec()
+            domain = [('autosave', '=', True)]
 
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.env.ref('clouder.clouder_settings').end_save_all = now
-        self.env.cr.commit()
+            containers = self.env['clouder.container'].search(domain)
+            for container in containers:
+                container.save_exec()
+
+            bases = self.env['clouder.base'].search(domain)
+            for base in bases:
+                base.save_exec()
+
+            links = self.env['clouder.container.link'].search([
+                ('container_id.application_id.type_id.name', '=', 'backup'),
+                ('name.code', '=', 'backup-upload'),
+            ])
+            for link in links:
+                link.deploy_exec()
+
+            now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.settings_id.end_save_all = now
 
     @api.multi
     def purge_expired_saves(self):
@@ -178,13 +201,17 @@ class ClouderConfigSettings(models.Model):
     def update_containers_exec(self):
         """
         """
-        containers = self.env['clouder.container'].search(
-            [('application_id.update_strategy', '=', 'auto')])
-        containers.update_exec()
 
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.env.ref('clouder.clouder_settings').end_update_containers = now
-        self.env.cr.commit()
+        with self._private_env() as env:
+            self = self.with_env(env)
+
+            containers = self.env['clouder.container'].search([
+                ('application_id.update_strategy', '=', 'auto'),
+            ])
+            containers.update_exec()
+
+            now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.settings_id.end_update_containers = now
 
     @api.multi
     def reset_bases(self):
@@ -195,17 +222,22 @@ class ClouderConfigSettings(models.Model):
         """
         Reset all bases marked for reset.
         """
-        bases = self.env['clouder.base'].search(
-            [('reset_each_day', '=', True)])
-        for base in bases:
-            if base.parent_id:
-                base.reset_base()
-            else:
-                bases.reinstall()
 
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.env.ref('clouder.clouder_settings').end_reset_bases = now
-        self.env.cr.commit()
+        with self._private_env() as env:
+            self = self.with_env(env)
+
+            bases = self.env['clouder.base'].search([
+                ('reset_each_day', '=', True),
+            ])
+
+            for base in bases:
+                if base.parent_id:
+                    base.reset_base()
+                else:
+                    bases.reinstall()
+
+            now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.settings_id.end_reset_bases = now
 
     @api.multi
     def certs_renewal(self):
@@ -216,15 +248,19 @@ class ClouderConfigSettings(models.Model):
         """
         Reset all bases marked for reset.
         """
-        bases = self.env['clouder.base'].search(
-            [('cert_renewal_date', '!=', False),
-             ('cert_renewal_date', '<=', self.now_date)])
-        for base in bases:
-            base.renew_cert()
 
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.env.ref('clouder.clouder_settings').end_certs_renewal = now
-        self.env.cr.commit()
+        with self._private_env() as env:
+            self = self.with_env(env)
+
+            bases = self.env['clouder.base'].search([
+                ('cert_renewal_date', '!=', False),
+                ('cert_renewal_date', '<=', self.now_date),
+            ])
+            for base in bases:
+                base.renew_cert()
+
+            now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.settings_id.end_certs_renewal = now
 
     @api.multi
     def cron_daily(self):

--- a/clouder/container.py
+++ b/clouder/container.py
@@ -23,6 +23,7 @@
 from openerp import models, fields, api
 from openerp import modules
 
+import os.path
 import socket
 import re
 
@@ -49,113 +50,57 @@ class ClouderServer(models.Model):
 
     _name = 'clouder.server'
     _inherit = ['clouder.model']
+    _sql_constraints = [
+        ('name_uniq', 'unique(name, domain_id)',
+         'Name must be unique!'),
+        ('ip_uniq', 'unique(ip, ssh_port)',
+         'IP/SSH must be unique!'),
+    ]
 
-    @api.multi
-    def _create_key(self):
-        """
-        Generate a key on the filesystem.
-        """
-        if not self.env.ref('clouder.clouder_settings').email_sysadmin:
-            self.raise_error(
-                "You need to specify the sysadmin email in configuration",
-            )
-
-        self.execute_local(['mkdir', '/tmp/key_' + str(self.env.uid)])
-        self.execute_local([
-            'ssh-keygen', '-t', 'rsa', '-C', self.email_sysadmin, '-f',
-            '/tmp/key_' + str(self.env.uid) + '/key', '-N', ''])
-        return True
-
-    @api.multi
-    def _destroy_key(self):
-        """
-        Destroy the key after once we don't need it anymore.
-        """
-        self.execute_local(['rm', '-rf', '/tmp/key_' + str(self.env.uid)])
-        return True
-
-    @api.multi
+    @api.model
     def _default_private_key(self):
         """
         Generate a couple of keys visible use on the server form, which
         we can easily add to the server to connect it.
         """
-        self = self.env['clouder.server']
 
         destroy = True
-        if not self.local_dir_exist('/tmp/key_' + str(self.env.uid)):
+        if not self.local_dir_exist(self.get_directory_key()):
             self._create_key()
             destroy = False
 
-        key = self.execute_local(
-            ['cat', '/tmp/key_' + str(self.env.uid) + '/key'])
+        key = self.execute_local([
+            'cat', self.get_directory_key('key'),
+        ])
 
         if destroy:
             self._destroy_key()
         return key
 
-    @api.multi
+    @api.model
     def _default_public_key(self):
         """
         Generate a couple of keys visible use on the server form, which
         we can easily add to the server to connect it.
         """
-        self = self.env['clouder.server']
 
         destroy = True
-        if not self.local_dir_exist('/tmp/key_' + str(self.env.uid)):
+        if not self.local_dir_exist(self.get_directory_key()):
             self._create_key()
             destroy = False
 
         key = self.execute_local([
-            'cat', '/tmp/key_' + str(self.env.uid) + '/key.pub'])
+            'cat', self.get_directory_key('key.pub'),
+        ])
 
         if destroy:
             self._destroy_key()
         return key
 
-    @api.multi
-    @api.depends('private_key')
-    def _compute_private_key(self):
-        for server in self:
-            key_file = \
-                server.home_directory + '/.ssh/keys/' + \
-                server.name + '.' + server.domain_id.name
-            server.private_key = self.execute_local(['cat', key_file])
-
-    @api.multi
-    @api.depends('public_key')
-    def _compute_public_key(self):
-        for server in self:
-            key_file = server.home_directory + '/.ssh/keys/' \
-                + server.name + '.' + server.domain_id.name
-            server.public_key = self.execute_local(['cat', key_file + '.pub'])
-
-    @api.multi
-    def _inverse_private_key(self):
-        """
-        """
-        for server in self:
-            name = server.fulldomain
-            self.execute_local(
-                ['mkdir', '-p', server.home_directory + '/.ssh/keys'])
-            key_file = server.home_directory + '/.ssh/keys/' + name
-            self.execute_write_file(key_file, server.private_key, operator='w')
-            self.execute_local(['chmod', '700', key_file])
-
-    @api.multi
-    def _inverse_public_key(self):
-        """
-        """
-        for server in self:
-            self.execute_local(
-                ['mkdir', '-p', server.home_directory + '/.ssh/keys'])
-            key_file = \
-                server.home_directory + '/.ssh/keys/' + server.fulldomain
-            self.execute_write_file(
-                key_file + '.pub', server.public_key, operator='w')
-            self.execute_local(['chmod', '700', key_file + '.pub'])
-
+    key_file = fields.Char(
+        compute='_compute_key_file',
+        store=True,
+    )
     name = fields.Char('Prefix', required=True)
     domain_id = fields.Many2one('clouder.domain', 'Domain', required=True)
     ip = fields.Char('IP')
@@ -165,11 +110,17 @@ class ClouderServer(models.Model):
     ssh_port = fields.Integer('SSH port', default='22')
 
     private_key = fields.Text(
-        'SSH Private Key', default=_default_private_key,
-        compute='_compute_private_key', inverse='_inverse_private_key')
+        'SSH Private Key',
+        default=lambda s: s._default_private_key(),
+        compute='_compute_private_key',
+        inverse='_inverse_private_key',
+    )
     public_key = fields.Text(
-        'SSH Public Key', default=_default_public_key,
-        compute='_compute_public_key', inverse='_inverse_public_key')
+        'SSH Public Key',
+        default=lambda s: s._default_public_key(),
+        compute='_compute_public_key',
+        inverse='_inverse_public_key',
+    )
     start_port = fields.Integer('Start Port', required=True)
     end_port = fields.Integer('End Port', required=True)
     public_ip = fields.Boolean(
@@ -189,25 +140,100 @@ class ClouderServer(models.Model):
         'container_id', 'oneclick_id', 'Oneclick Deployment')
     oneclick_ports = fields.Boolean('Assign critical ports?')
 
+    @api.multi
+    @api.depends('name', 'domain_id.name')
+    def _compute_key_file(self):
+        for server in self:
+            server.key_file = os.path.join(
+                server.home_directory, '.ssh', 'keys',
+                '%s.%s' % (server.name, server.domain_id.name),
+            )
+
+    @api.multi
+    def _create_key(self):
+        """
+        Generate a key on the filesystem.
+        """
+        if not self.env.ref('clouder.clouder_settings').email_sysadmin:
+            self.raise_error(
+                "You need to specify the sysadmin email in configuration",
+            )
+
+        self.execute_local(['mkdir', self.get_directory_key()])
+        self.execute_local([
+            'ssh-keygen', '-t', 'rsa', '-C', self.email_sysadmin, '-f',
+            self.get_directory_key('key'), '-N', '',
+        ])
+        return True
+
+    @api.multi
+    def _destroy_key(self):
+        """
+        Destroy the key after once we don't need it anymore.
+        """
+        self.execute_local(['rm', '-rf', self.get_directory_key()])
+        return True
+
+    @api.multi
+    @api.depends('private_key', 'key_file')
+    def _compute_private_key(self):
+        for server in self:
+            server.private_key = self.execute_local(['cat', server.key_file])
+
+    @api.multi
+    @api.depends('public_key', 'key_file')
+    def _compute_public_key(self):
+        for server in self:
+            server.public_key = self.execute_local([
+                'cat', '%s.pub' % server.key_file,
+            ])
+
+    @api.multi
+    def _inverse_private_key(self):
+        """
+        """
+        for server in self:
+            name = server.fulldomain
+            self.execute_local([
+                'mkdir', '-p',
+                os.path.join(server.home_directory, '.ssh', 'keys'),
+            ])
+            key_file = os.path.join(
+                server.home_directory, '.ssh', 'keys', name,
+            )
+            self.execute_write_file(
+                key_file, server.private_key, operator='w',
+            )
+            self.execute_local(['chmod', '700', key_file])
+
+    @api.multi
+    def _inverse_public_key(self):
+        """
+        """
+        for server in self:
+            key_dir = os.path.join(server.home_directory, '.ssh', 'keys')
+            self.execute_local(['mkdir', '-p', key_dir])
+            key_file = os.path.join(key_dir, server.fulldomain)
+            key_file_pub = '%s.pub' % key_file
+            self.execute_write_file(
+                key_file_pub, server.public_key, operator='w',
+            )
+            self.execute_local(['chmod', '700', key_file_pub])
+
     @property
     def fulldomain(self):
         """
         """
 
-        fulldomain = self.name + '.' + self.domain_id.name
+        fulldomain = '%s.%s' % (self.name, self.domain_id.name)
         if self.control_dns and self.domain_id.dns_id:
             ip = socket.gethostbyname(fulldomain)
             if ip != self.ip:
                 self.raise_error(
-                    "Couldn't resolve hostname of the server " + fulldomain)
+                    'Could not resolve hostname of the server "%s"',
+                    fulldomain,
+                )
         return fulldomain
-
-    _sql_constraints = [
-        ('name_uniq', 'unique(name, domain_id)',
-         'Name must be unique!'),
-        ('ip_uniq', 'unique(ip, ssh_port)',
-         'IP/SSH must be unique!'),
-    ]
 
     @api.multi
     @api.constrains('name', 'ip')
@@ -229,26 +255,27 @@ class ClouderServer(models.Model):
     def deploy_ssh_config(self):
         for server in self:
             name = server.fulldomain
-            self.execute_local([modules.get_module_path('clouder') +
-                                '/res/sed.sh', name,
-                                self.home_directory + '/.ssh/config'])
-            self.execute_write_file(self.home_directory +
-                                    '/.ssh/config', 'Host ' + name)
+            ssh_config = os.path.join(self.home_directory, '.ssh', 'config')
+            sed = os.path.join(
+                modules.get_module_path('clouder'), 'res', 'sed.sh',
+            )
+            self.execute_local([sed, name, ssh_config])
+            self.execute_write_file(ssh_config, 'Host %s' % name)
             self.execute_write_file(
-                server.home_directory +
-                '/.ssh/config', '\n  HostName ' + server.ip)
-            self.execute_write_file(server.home_directory +
-                                    '/.ssh/config', '\n  Port ' +
-                                    str(server.ssh_port))
+                ssh_config, '\n  HostName %s' % server.ip,
+            )
             self.execute_write_file(
-                server.home_directory + '/.ssh/config',
-                '\n  User ' + (server.login or 'root'))
+                ssh_config, '\n  Port %s' % server.ssh_port,
+            )
             self.execute_write_file(
-                server.home_directory + '/.ssh/config',
-                '\n  IdentityFile ~/.ssh/keys/' + name)
+                ssh_config, '\n  User %s' % (server.login or 'root'),
+            )
             self.execute_write_file(
-                server.home_directory + '/.ssh/config',
-                '\n#END ' + name + '\n')
+                ssh_config, '\n  IdentityFile ~/.ssh/keys/%s' % name,
+            )
+            self.execute_write_file(
+                ssh_config, '\n#END %s\n' % name,
+            )
 
     @api.multi
     def write(self, vals):
@@ -316,7 +343,7 @@ class ClouderServer(models.Model):
     @api.multi
     def deploy_dns(self):
         self = self.with_context(no_enqueue=True)
-        self.do('deploy_dns ' + self.fulldomain, 'deploy_dns_exec')
+        self.do('deploy_dns %s' % self.fulldomain, 'deploy_dns_exec')
 
     @api.multi
     def deploy_dns_exec(self):
@@ -324,8 +351,10 @@ class ClouderServer(models.Model):
 
         if self.domain_id.dns_id:
             self.domain_id.dns_id.execute([
-                'echo "' + self.name + ' IN A ' + self.ip +
-                '" >> ' + self.domain_id.configfile])
+                'echo "%s IN A %s" >> "%s"' % (
+                    self.name, self.ip, self.domain_id.configfile,
+                )
+            ])
             self.domain_id.refresh_serial(self.fulldomain)
             # self.control_dns = True
 
@@ -339,9 +368,9 @@ class ClouderServer(models.Model):
         self.control_dns = False
         if self.domain_id.dns_id:
             self.domain_id.dns_id.execute([
-                'sed', '-i',
-                '"/' + self.name + r'\sIN\sA/d"',
-                self.domain_id.configfile])
+                'sed', '-i', r'"/%s\sIN\sA/d"' % self.name,
+                self.domain_id.configfile,
+            ])
             self.domain_id.refresh_serial()
 
     @api.multi
@@ -463,29 +492,10 @@ class ClouderContainer(models.Model):
 
     _name = 'clouder.container'
     _inherit = ['clouder.model']
-
-    @api.multi
-    def _compute_ports(self):
-        """
-        Display the ports on the container lists.
-        """
-        for rec in self:
-            rec.ports_string = ''
-            first = True
-            for port in rec.port_ids:
-                if not first:
-                    rec.ports_string += ', '
-                if port.hostport:
-                    rec.ports_string += port.name + ' : ' + port.hostport
-                first = False
-
-    @api.multi
-    def _compute_name(self):
-        """
-        Return the name of the container
-        """
-        for rec in self:
-            rec.name = rec.environment_id.prefix + '-' + rec.suffix
+    _sql_constraints = [
+        ('name_uniq', 'unique(server_id,environment_id,suffix)',
+         'Name must be unique per server!'),
+    ]
 
     name = fields.Char('Name', compute='_compute_name', required=False)
     environment_id = fields.Many2one('clouder.environment', 'Environment',
@@ -532,20 +542,44 @@ class ClouderContainer(models.Model):
     public = fields.Boolean('Public?')
     dummy = fields.Boolean('Dummy?')
 
+    @api.multi
+    def _compute_ports(self):
+        """
+        Display the ports on the container lists.
+        """
+        for rec in self:
+            rec.ports_string = ''
+            first = True
+            for port in rec.port_ids:
+                if not first:
+                    rec.ports_string += ', '
+                if port.hostport:
+                    rec.ports_string += '%s : %s' % (port.name, port.hostport)
+                first = False
+
+    @api.multi
+    def _compute_name(self):
+        """
+        Return the name of the container
+        """
+        for rec in self:
+            rec.name = '%s-%s' % (rec.environment_id.prefix, rec.suffix)
+
     @property
     def fullname(self):
         """
         Property returning the full name of the container.
         """
-        return self.name + '_' + self.server_id.fulldomain
+        return '%s_%s' % (self.name, self.server_id.fulldomain)
 
     @property
     def volumes_save(self):
         """
         Property returning the all volume path, separated by a comma.
         """
-        return ','.join([volume.name for volume in self.volume_ids
-                         if not volume.nosave])
+        return ','.join([
+            volume.name for volume in self.volume_ids if not volume.nosave
+        ])
 
     @property
     def root_password(self):
@@ -693,11 +727,6 @@ class ClouderContainer(models.Model):
         for code, child in self.childs.iteritems():
             links[code] = child
         return links
-
-    _sql_constraints = [
-        ('name_uniq', 'unique(server_id,environment_id,suffix)',
-         'Name must be unique per server!'),
-    ]
 
     @api.multi
     @api.constrains('environment_id')

--- a/clouder/container.py
+++ b/clouder/container.py
@@ -51,10 +51,10 @@ class ClouderServer(models.Model):
     _name = 'clouder.server'
     _inherit = ['clouder.model']
     _sql_constraints = [
-        ('name_uniq', 'unique(name, domain_id)',
-         'Name must be unique!'),
-        ('ip_uniq', 'unique(ip, ssh_port)',
-         'IP/SSH must be unique!'),
+        ('domain_id_name_uniq', 'unique(domain_id, name)',
+         'This name already exists on this domain.'),
+        ('ip_ssh_port_uniq', 'unique(ip, ssh_port)',
+         'Another server is already setup for this SSH Address and Port.'),
     ]
 
     @api.model
@@ -204,7 +204,7 @@ class ClouderServer(models.Model):
             self.execute_write_file(
                 key_file, server.private_key, operator='w',
             )
-            self.execute_local(['chmod', '700', key_file])
+            self.execute_local(['chmod', '600', key_file])
 
     @api.multi
     def _inverse_public_key(self):
@@ -218,7 +218,7 @@ class ClouderServer(models.Model):
             self.execute_write_file(
                 key_file_pub, server.public_key, operator='w',
             )
-            self.execute_local(['chmod', '700', key_file_pub])
+            self.execute_local(['chmod', '600', key_file_pub])
 
     @property
     def fulldomain(self):

--- a/clouder/environment.py
+++ b/clouder/environment.py
@@ -45,7 +45,7 @@ class ClouderEnvironment(models.Model):
 
     name = fields.Char('Name', required=True)
     partner_id = fields.Many2one('res.partner', 'Partner', required=True)
-    prefix = fields.Char('Prefix', required=True)
+    prefix = fields.Char('Prefix', required=False)
     user_ids = fields.Many2many(
         'res.users', 'clouder_environment_user_rel',
         'environment_id', 'user_id', 'Users')

--- a/clouder/exceptions.py
+++ b/clouder/exceptions.py
@@ -19,7 +19,11 @@ class ClouderError(ValidationError):
         :param message: (str) Message to throw and log
         :raises: (ClouderError) Exception after generating appropriate log
         """
-        model_obj.log('Raising error: "%s"' % message)
-        model_obj.log('Version: "%s"' % model_obj.version)
+        try:
+            model_obj.log('Raising error: "%s"' % message)
+            model_obj.log('Version: "%s"' % model_obj.version)
+        except AttributeError:
+            # Model does not _inherit `clouder.model`
+            pass
         self.model_obj = model_obj
         super(ClouderError, self).__init__(message)

--- a/clouder/image.py
+++ b/clouder/image.py
@@ -83,34 +83,33 @@ class ClouderImage(models.Model):
 
     @property
     def computed_dockerfile(self):
-        dockerfile = 'FROM '
+
+        dockerfile = ['FROM ']
+
         if self.parent_id and self.parent_version_id:
-            dockerfile += self.parent_version_id.fullpath
+            dockerfile.append(self.parent_version_id.fullpath)
         elif self.parent_from:
-            dockerfile += self.parent_from
+            dockerfile.append(self.parent_from)
         else:
             self.raise_error(
                 "You need to specify the image to inherit!",
             )
 
-        dockerfile += '\nMAINTAINER %s\n' % (
-            self.env['clouder.model'].email_sysadmin,
+        dockerfile.append(
+            '\nMAINTAINER %s\n' % (self.env['clouder.model'].email_sysadmin),
         )
 
-        dockerfile += self.dockerfile or ''
-        volumes = ''
-        for volume in self.volume_ids:
-            volumes += volume.name + ' '
+        dockerfile.append(self.dockerfile or '')
+
+        volumes = [v.name for v in self.volume_ids]
         if volumes:
-            dockerfile += '\nVOLUME %s' % volumes
+            dockerfile.append('\nVOLUME %s' % ' '.join(volumes))
 
-        ports = ''
-        for port in self.port_ids:
-            ports += '%s ' % port.localport
+        ports = [p.localport for p in self.port_ids]
         if ports:
-            dockerfile += '\nEXPOSE %s' % ports
+            dockerfile.append('\nEXPOSE %s' % ' '.join(ports))
 
-        return dockerfile
+        return ''.join(dockerfile)
 
     @api.multi
     @api.constrains('name')

--- a/clouder/model.py
+++ b/clouder/model.py
@@ -23,7 +23,6 @@
 import errno
 import logging
 import os.path
-import random
 import re
 import requests
 import select
@@ -34,8 +33,9 @@ import time
 from contextlib import contextmanager
 from datetime import datetime
 from os.path import expanduser
+from random import SystemRandom
 
-from openerp import models, fields, api, _, release, registry
+from openerp import models, fields, api, _, release
 
 from .exceptions import ClouderError
 
@@ -46,7 +46,23 @@ try:
 except ImportError:
     _logger.warning('Cannot `import paramiko`.')
 
+
 ssh_connections = {}
+
+
+def generate_random_password(size, punctuation=True):
+    """ Method which can be used to generate a random password.
+
+    :param size: (int) The size of the random string to generate
+    :param punctuation: (bool) Allow punctuation in the password
+    :return: (str) Psuedo-random string
+    """
+    choice = SystemRandom().choice
+    chars = '%s%s%s' % (
+        string.letters, string.digits,
+        punctuation and string.punctuation or '',
+    )
+    return ''.join(choice(chars) for _ in xrange(size))
 
 
 class ClouderJob(models.Model):
@@ -186,7 +202,7 @@ class ClouderModel(models.AbstractModel):
         now = datetime.now()
         return now.strftime("%Y-%m-%d-%H%M%S")
 
-    @api.model
+    @api.multi
     def get_directory_key(self, add_path=None):
         """ It returns the current working directory for keys
         :param add_path: (str|iter) String or Iterator of Strings indicating
@@ -196,7 +212,7 @@ class ClouderModel(models.AbstractModel):
         name = 'key_%s' % self.env.uid
         return self._get_directory_tmp(name, add_path)
 
-    @api.model
+    @api.multi
     def get_directory_clouder(self, add_path=None):
         """ It returns the current clouder directory on the remote
         :param add_path: (str|iter) String or Iterator of Strings indicating
@@ -205,7 +221,7 @@ class ClouderModel(models.AbstractModel):
         """
         return self._get_directory_tmp('clouder', add_path)
 
-    @api.model
+    @api.multi
     def _get_directory_tmp(self, name, add_path=None):
         """ It returns a directory in tmp for name
         :param name: (str) Name of the directory in tmp
@@ -219,19 +235,24 @@ class ClouderModel(models.AbstractModel):
             add_path = [str(add_path)]
         return os.path.join('/tmp', str(name), *add_path)
 
-    @api.model
+    @api.multi
     @contextmanager
     def _private_env(self):
         """ It provides an isolated environment/commit
 
+        Usage:
+            ``with self._private_env() as self``
+
         Yields:
-            ``openerp.api.Environment`` to be used with ``model.with_env``
+            Current ``self``, but in a new environment
         """
-        with api.Environment.manage():
-            with registry(self.env.cr.dbname).cursor() as cr:
-                env = api.Environment(cr, self.env.uid, self.env.context)
-                yield env
-                env.cr.commit()  # pylint: disable=E8102
+        # with api.Environment.manage():
+        #     with registry(self.env.cr.dbname).cursor() as cr:
+        #         env = api.Environment(cr, self.env.uid, self.env.context)
+        #         _logger.debug('Created new env %s for %s', env, self)
+        yield self
+        self.env.cr.commit()  # pylint: disable=E8102
+        #         _logger.debug('Cursor %s has been committed', cr)
 
     @api.multi
     @api.constrains('name')
@@ -267,11 +288,10 @@ class ClouderModel(models.AbstractModel):
         :param message: The message which will be logged.
         """
 
-        with self._private_env() as env:
-            self = self.with_env(env)
+        with self._private_env() as self:
 
             job_obj = self.env['clouder.job']
-            now = datetime.now()
+            now = fields.Datetime.now()
             message = re.sub(r'$$$\w+$$$', '**********', message)
             message = filter(lambda x: x in string.printable, message)
             _logger.info(message)
@@ -285,10 +305,11 @@ class ClouderModel(models.AbstractModel):
                     if job.state == 'started':
                         job.log = '%s%s : %s\n' % (
                             (job.log or ''),
-                            now.strftime('%Y-%m-%d %H:%M:%S'),
+                            now,
                             message,
                         )
 
+    @api.multi
     def raise_error(self, message, interpolations=None):
         """ Raises a ClouderError with a translated message
         :param message: (str) Message including placeholders for string
@@ -695,15 +716,16 @@ class ClouderModel(models.AbstractModel):
             destination = os.path.join(tmp_dir, 'file')
 
         sftp = ssh.open_sftp()
-        self.log('send : ' + source + ' to ' + destination)
+        self.log('send: "%s" to "%s"' % (source, destination))
         sftp.put(source, destination)
         sftp.close()
 
         if tmp_dir:
             server.execute([
                 'cat', destination, '|', 'docker', 'exec', '-i',
-                username and ('-u ' + username) or '',
-                self.name, 'sh', '-c', "'cat > " + final_destination + "'"])
+                username and ('-u %s' % username) or '',
+                self.name, 'sh', '-c', "'cat > %s'" % final_destination,
+            ])
 #            if username:
 #                server.execute([
 #                    'docker', 'exec', '-i', self.name,
@@ -765,7 +787,7 @@ class ClouderModel(models.AbstractModel):
         sftp = ssh.open_sftp()
         try:
             sftp.stat(path)
-        except IOError, e:
+        except IOError as e:
             if e.errno == errno.ENOENT:
                 sftp.close()
                 return False
@@ -807,29 +829,35 @@ class ClouderModel(models.AbstractModel):
             self, url, method='get', headers=None,
             data=None, params=None, files=None):
 
-        if not headers:
-            headers = {}
-        if not data:
-            data = {}
-        if not params:
-            params = {}
-        if not files:
-            files = {}
+        self.log('request "%s" "%s"' % (method, url))
 
-        self.log('request ' + method + ' ' + url)
-        if headers:
-            self.log('headers ' + str(headers))
-        if data:
-            self.log('data ' + str(data))
-        if params:
-            self.log('params ' + str(params))
-        if files:
-            self.log('files ' + str(files))
+        if headers is None:
+            headers = {}
+        else:
+            self.log('request "%s" "%s"' % (method, url))
+
+        if data is None:
+            data = {}
+        else:
+            self.log('data %s' % data)
+
+        if params is None:
+            params = {}
+        else:
+            self.log('params %s' % params)
+
+        if files is None:
+            files = {}
+        else:
+            self.log('files %s' % files)
+
         result = requests.request(
             method, url, headers=headers, data=data,
-            params=params, files=files, verify=False)
-        self.log('status ' + str(result.status_code) + ' ' + result.reason)
-        self.log('result ' + str(result.json()))
+            params=params, files=files, verify=False,
+        )
+        self.log('status %s %s' % (result.status_code, result.reason))
+        self.log('result %s' % result.json())
+
         return result
 
 
@@ -879,15 +907,3 @@ class ClouderTemplateOne2many(models.AbstractModel):
         res = super(ClouderTemplateOne2many, self).write(vals)
         self.reset_template()
         return res
-
-
-def generate_random_password(size):
-    """
-    Method which can be used to generate a random password.
-
-    :param size: The size of the random string we need to generate.
-    """
-    return ''.join(
-        random.choice(string.ascii_uppercase + string.ascii_lowercase +
-                      string.digits)
-        for _ in range(size))

--- a/clouder/save.py
+++ b/clouder/save.py
@@ -269,8 +269,8 @@ class ClouderSave(models.Model):
 
         self.ensure_one()
 
-        self.log('Saving ' + self.name)
-        self.log('Comment: ' + self.comment)
+        self.log('Saving "%s"' % self.name)
+        self.log('Comment: "%s"' % self.comment)
 
         container = 'exec' in self.container_id.childs \
                     and self.container_id.childs['exec'] or self.container_id


### PR DESCRIPTION
[IMP] clouder: Centralize and improve path/str handling  …
* Centralize key and clouder tmp dirs via `ClouderModel` method
* Centralize backup directory definitions in `ClouderModel`
* Harden path handling by using os.path.join
* Prefer string interpolation vs concat
* Fix use of `self.raise_error` for models that aren't inherited from `clouder.model`
* Prefer `ClouderError` in models not inherited from `clouder.model`
* Update model attribute declaration orders
* Use lambdas for defaults in `clouder.container`
* Environment prefix is required
* Centralize commit methods and use isolated environment
* Change version to `9.0.2.0.0` to match OCA style for 9, while keeping w/ semantic increase
