### PR TITLE
[IMP] Add support for Docker Compose and Docker Swarm

### DIFF
--- a/clouder/clouder_runner_docker/runner.py
+++ b/clouder/clouder_runner_docker/runner.py
@@ -231,8 +231,7 @@ class ClouderContainer(models.Model):
         self.server_id.execute(['rm', '-rf', build_dir])
         self.server_id.execute(['mkdir', '-p', build_dir])
         self.server_id.execute(
-            ['echo "' + compose + '" > ' +
-             build_dir + '/' + 'docker-compose.yml'])
+            ['echo "%s" > %s/docker-compose.yml' % (compose, build_dir)])
         return build_dir
 
     @api.multi

--- a/clouder/clouder_runner_docker/runner.py
+++ b/clouder/clouder_runner_docker/runner.py
@@ -237,7 +237,7 @@ class ClouderContainer(models.Model):
                 == 'docker':
 
             if False:  # not self.application_id.check_tags(['no-salt']):
-                print 'TODO'
+                self.log('TODO')
             else:
                 # Create build directory and deploy
                 build_dir = self.refresh_compose_file()
@@ -377,7 +377,7 @@ class ClouderContainer(models.Model):
                 == 'docker':
 
             if False:  # not self.application_id.check_tags(['no-salt']):
-                print 'TODO'
+                self.log('TODO')
             else:
                 # Ensure build directory is up-to-date and purge
                 build_dir = self.refresh_compose_file()

--- a/clouder/clouder_runner_docker/template.xml
+++ b/clouder/clouder_runner_docker/template.xml
@@ -25,17 +25,18 @@
             <field name="parent_from">clouder/clouder-docker</field>
             <field name="parent_id"/>
             <field name="dockerfile"/>
-</record>
-<record id="image_docker_volume_docker" model="clouder.image.volume">
-    <field name="image_id" ref="image_docker"/>
-    <field name="name">/var/lib/docker</field>
-</record>
-<record id="image_docker_port_ssh" model="clouder.image.port">
-    <field name="image_id" ref="image_docker"/>
-    <field name="name">ssh</field>
-    <field name="localport">22</field>
-    <field name="expose">internet</field>
-</record>
+        </record>
+        <record id="image_docker_volume_docker" model="clouder.image.volume">
+            <field name="image_id" ref="image_docker"/>
+            <field name="name">docker</field>
+            <field name="localpath">/var/lib/docker</field>
+        </record>
+        <record id="image_docker_port_ssh" model="clouder.image.port">
+            <field name="image_id" ref="image_docker"/>
+            <field name="name">ssh</field>
+            <field name="localport">22</field>
+            <field name="expose">internet</field>
+        </record>
 
 
 

--- a/clouder/clouder_template_backup/template.xml
+++ b/clouder/clouder_template_backup/template.xml
@@ -38,7 +38,8 @@
         </record>
         <record id="image_template_backup_upload_volume_upload" model="clouder.image.volume">
             <field name="template_id" ref="image_template_backup_upload"/>
-            <field name="name">/opt/upload</field>
+            <field name="name">upload</field>
+            <field name="localpath">/opt/upload</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_backup_upload" model="clouder.image">
@@ -74,7 +75,8 @@
         </record>
         <record id="image_template_backup_simple_volume_backup" model="clouder.image.volume">
             <field name="template_id" ref="image_template_backup_simple"/>
-            <field name="name">/opt/backup</field>
+            <field name="name">backup</field>
+            <field name="localpath">/opt/backup</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_backup_simple" model="clouder.image">
@@ -115,7 +117,8 @@
         </record>
         <record id="image_template_backup_bup_volume_backup" model="clouder.image.volume">
             <field name="template_id" ref="image_template_backup_bup"/>
-            <field name="name">/opt/backup</field>
+            <field name="name">backup</field>
+            <field name="localpath">/opt/backup</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_template_backup_bup_port_web" model="clouder.image.port">

--- a/clouder/clouder_template_registry/template.xml
+++ b/clouder/clouder_template_registry/template.xml
@@ -13,15 +13,18 @@
         </record>
         <record id="image_template_registry_data_volume_auth" model="clouder.image.volume">
             <field name="template_id" ref="image_template_registry_data"/>
-            <field name="name">/auth</field>
+            <field name="name">auth</field>
+            <field name="localpath">/auth</field>
         </record>
         <record id="image_template_registry_data_volume_certs" model="clouder.image.volume">
             <field name="template_id" ref="image_template_registry_data"/>
-            <field name="name">/certs</field>
+            <field name="name">certs</field>
+            <field name="localpath">/certs</field>
         </record>
         <record id="image_template_registry_data_volume_var" model="clouder.image.volume">
             <field name="template_id" ref="image_template_registry_data"/>
-            <field name="name">/var/lib/registry</field>
+            <field name="name">var</field>
+            <field name="localpath">/var/lib/registry</field>
         </record>
         <record id="image_registry_data" model="clouder.image">
             <field name="name">image_registry_data</field>

--- a/clouder/clouder_template_salt/template.py
+++ b/clouder/clouder_template_salt/template.py
@@ -91,6 +91,7 @@ class ClouderContainer(models.Model):
 
     @api.multi
     def deploy_salt(self):
+        return
 
         self.purge_salt()
 
@@ -118,6 +119,11 @@ class ClouderContainer(models.Model):
                     bases[base.fullname_] = base.fullname_
         data['bases'] = [base for key, base in bases.iteritems()]
         data.update(self.get_container_res())
+
+        links = []
+        for link in data['links']:
+            links.append(link['name'] + ':' + link['code'])
+        data['links'] = links
 
         data = {self.name: data}
 
@@ -252,6 +258,7 @@ class ClouderBase(models.Model):
 
     @api.multi
     def deploy_salt(self):
+        return
 
         self.purge_salt()
 

--- a/clouder/clouder_template_salt/template.py
+++ b/clouder/clouder_template_salt/template.py
@@ -91,7 +91,6 @@ class ClouderContainer(models.Model):
 
     @api.multi
     def deploy_salt(self):
-        return
 
         self.purge_salt()
 
@@ -258,7 +257,6 @@ class ClouderBase(models.Model):
 
     @api.multi
     def deploy_salt(self):
-        return
 
         self.purge_salt()
 

--- a/clouder/clouder_template_salt/template.py
+++ b/clouder/clouder_template_salt/template.py
@@ -65,7 +65,8 @@ class ClouderServer(models.Model):
                         self.fulldomain + '/d"',
                         '/srv/pillar/top.sls'])
                     master.execute([
-                        'rm', '/etc/salt/pki/master/minions/' + self.fulldomain])
+                        'rm',
+                        '/etc/salt/pki/master/minions/' + self.fulldomain])
                     master.execute([
                         'rm', '/etc/salt/pki/master/minions_denied/' +
                         self.fulldomain])
@@ -74,7 +75,8 @@ class ClouderServer(models.Model):
             try:
                 minion = self.env['clouder.container'].search(
                     [('environment_id', '=', self.environment_id.id),
-                     ('server_id', '=', self.id), ('suffix', '=', 'salt-minion')])
+                     ('server_id', '=', self.id),
+                     ('suffix', '=', 'salt-minion')])
                 minion.unlink()
             except:
                 pass

--- a/clouder/clouder_template_salt/template.py
+++ b/clouder/clouder_template_salt/template.py
@@ -46,8 +46,8 @@ class ClouderServer(models.Model):
             master.execute(['salt-key', '-y', '--accept=' + self.fulldomain])
 
             master.execute([
-                'echo "  \'' + self.fulldomain + '\':\n#END ' +
-                self.fulldomain + '" >> /srv/pillar/top.sls'])
+                'echo "  \'%s\':\n#END %s" >> /srv/pillar/top.sls' %
+                (self.fulldomain, self.fulldomain)])
 
     @api.multi
     def purge(self):
@@ -66,10 +66,10 @@ class ClouderServer(models.Model):
                         '/srv/pillar/top.sls'])
                     master.execute([
                         'rm',
-                        '/etc/salt/pki/master/minions/' + self.fulldomain])
+                        '/etc/salt/pki/master/minions/%s' % (self.fulldomain)])
                     master.execute([
-                        'rm', '/etc/salt/pki/master/minions_denied/' +
-                        self.fulldomain])
+                        'rm', '/etc/salt/pki/master/minions_denied/%s' %
+                        (self.fulldomain)])
                 except:
                     pass
             try:

--- a/clouder/clouder_template_salt/template.xml
+++ b/clouder/clouder_template_salt/template.xml
@@ -17,11 +17,13 @@
         </record>
         <record id="image_template_salt_master_data_volume_salt" model="clouder.image.volume">
             <field name="template_id" ref="image_template_salt_master_data"/>
-            <field name="name">/srv/salt</field>
+            <field name="name">salt</field>
+            <field name="localpath">/srv/salt</field>
         </record>
         <record id="image_template_salt_master_data_volume_pillar" model="clouder.image.volume">
             <field name="template_id" ref="image_template_salt_master_data"/>
-            <field name="name">/srv/pillar</field>
+            <field name="name">pillar</field>
+            <field name="localpath">/srv/pillar</field>
         </record>
 
 
@@ -61,7 +63,10 @@
             <field name="template_ids" eval="[(4, [ref('image_template_salt_master_data')])]"/>
             <field name="parent_from">clouder/clouder-salt-master-data</field>
             <field name="parent_id"/>
-            <field name="dockerfile"/>
+            <field name="dockerfile"><![CDATA[
+CMD tail -f /dev/null
+]]></field>
+
         </record>
 
         <record id="image_salt_master_exec" model="clouder.image">
@@ -118,7 +123,8 @@
         </record>
         <record id="image_template_salt_minion_volume_docker" model="clouder.image.volume">
             <field name="template_id" ref="image_template_salt_minion"/>
-            <field name="name">/var/run/docker.sock</field>
+            <field name="name">docker</field>
+            <field name="localpath">/var/run/docker.sock</field>
             <field name="hostpath">/var/run/docker.sock</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>

--- a/clouder/clouder_template_salt/template.xml
+++ b/clouder/clouder_template_salt/template.xml
@@ -118,7 +118,8 @@ CMD tail -f /dev/null
         </record>
         <record id="image_template_salt_minion_volume_etc" model="clouder.image.volume">
             <field name="template_id" ref="image_template_salt_minion"/>
-            <field name="name">/etc/nagios</field>
+            <field name="name">nagios</field>
+            <field name="localpath">/etc/nagios</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_template_salt_minion_volume_docker" model="clouder.image.volume">

--- a/clouder/data/data.xml
+++ b/clouder/data/data.xml
@@ -40,15 +40,18 @@
         </record>
         <record id="image_template_nginx_data_volume_nginx" model="clouder.image.volume">
             <field name="template_id" ref="image_template_nginx_data"/>
-            <field name="name">/etc/nginx</field>
+            <field name="name">nginx</field>
+            <field name="localpath">/etc/nginx</field>
         </record>
         <record id="image_template_nginx_data_volume_www" model="clouder.image.volume">
             <field name="template_id" ref="image_template_nginx_data"/>
-            <field name="name">/var/www</field>
+            <field name="name">www</field>
+            <field name="localpath">/var/www</field>
         </record>
         <record id="image_template_nginx_data_volume_ssl" model="clouder.image.volume">
             <field name="template_id" ref="image_template_nginx_data"/>
-            <field name="name">/etc/ssl</field>
+            <field name="name">ssl</field>
+            <field name="localpath">/etc/ssl</field>
         </record>
         <record id="image_nginx_data" model="clouder.image">
             <field name="name">image_nginx_data</field>

--- a/clouder/models/application_link.py
+++ b/clouder/models/application_link.py
@@ -26,7 +26,8 @@ class ClouderApplicationLink(models.Model):
     template_id = fields.Many2one(
         'clouder.application.template', 'Template',
         ondelete="cascade", required=False)
-    name = fields.Many2one('clouder.application', 'Application', required=True)
+    name = fields.Many2one('clouder.application', 'Application',
+                           ondelete="cascade", required=True)
     required = fields.Boolean('Required?')
     auto = fields.Boolean('Auto?')
     make_link = fields.Boolean('Make docker link?')

--- a/clouder/models/base.py
+++ b/clouder/models/base.py
@@ -727,7 +727,7 @@ class ClouderBase(models.Model):
             base_reset_fullname_=base_reset_id.fullname_)
         base = base.with_context(
             container_reset_name=base_reset_id.container_id.name)
-        base.deploy_salt()
+        # base.deploy_salt()
         base.update_exec()
         base.post_reset()
         base.deploy_post()
@@ -796,7 +796,7 @@ class ClouderBase(models.Model):
                 child.create_child_exec()
             return
 
-        self.deploy_salt()
+        # self.deploy_salt()
 
         self.deploy_database()
         self.log('Database created')
@@ -821,11 +821,11 @@ class ClouderBase(models.Model):
         self = self.with_context(save_comment='First save')
         self.save_exec(no_enqueue=True)
 
-        if self.application_id.update_bases:
-            self.container_id.deploy_salt()
-        for key, child in self.container_id.childs.iteritems():
-            if child.application_id.update_bases:
-                child.deploy_salt()
+        # if self.application_id.update_bases:
+        #     self.container_id.deploy_salt()
+        # for key, child in self.container_id.childs.iteritems():
+        #     if child.application_id.update_bases:
+        #         child.deploy_salt()
 
     @api.multi
     def purge_post(self):
@@ -849,13 +849,13 @@ class ClouderBase(models.Model):
         """
         self.purge_database()
         self.purge_post()
-        self.purge_salt()
+        # self.purge_salt()
 
-        if self.application_id.update_bases:
-            self.container_id.deploy_salt()
-        for key, child in self.container_id.childs.iteritems():
-            if child.application_id.update_bases:
-                child.deploy_salt()
+        # if self.application_id.update_bases:
+        #     self.container_id.deploy_salt()
+        # for key, child in self.container_id.childs.iteritems():
+        #     if child.application_id.update_bases:
+        #         child.deploy_salt()
 
         super(ClouderBase, self).purge()
 

--- a/clouder/models/config_settings.py
+++ b/clouder/models/config_settings.py
@@ -20,15 +20,18 @@ class ClouderConfigSettings(models.Model):
 
     name = fields.Char('Name')
     email_sysadmin = fields.Char('Email SysAdmin')
+    master_id = fields.Many2one(
+        'clouder.server', 'Master', readonly=True)
     salt_master_id = fields.Many2one(
         'clouder.container', 'Salt Master', readonly=True)
-    deployer = fields.Selection(
-        lambda s: s._get_deployers(),
-        string='Deployer', required=True, default='engine')
+    runner = fields.Selection(
+        lambda s: s._get_runners(),
+        string='Runner', required=True, default='swarm')
+    runner_id = fields.Many2one('clouder.container', 'Runner')
     executor = fields.Selection(
         lambda s: s._get_executors(),
-        string='Deployer', required=True, default='salt')
-    runner_id = fields.Many2one('clouder.container', 'Runner')
+        string='Executor', required=True, default='ssh')
+    compose = fields.Boolean('Compose? (Experimental)', default=False)
     end_reset_keys = fields.Datetime('Last Reset Keys ended at')
     end_save_all = fields.Datetime('Last Save All ended at')
     end_update_containers = fields.Datetime('Last Update Containers ended at')
@@ -38,14 +41,14 @@ class ClouderConfigSettings(models.Model):
         'clouder.provider', 'config_id', 'Providers')
 
     @api.multi
-    def _get_deployers(self):
+    def _get_runners(self):
         return [
-            ('engine', 'Docker Engine'), ('compose', 'Docker Compose'),
-            ('swarm', 'Docker Swarm'), ('runner', 'Custom Runner')]
+            ('engine', 'Docker Engine'), ('swarm', 'Docker Swarm'),
+            ('custom', 'Custom Runner')]
 
     @api.multi
     def _get_executors(self):
-        return [('ssh', 'SSH'), ('salt', 'Salt')]
+        return [('ssh', 'SSH'), ('salt', 'Salt (Experimental)')]
 
     @property
     def now_date(self):

--- a/clouder/models/config_settings.py
+++ b/clouder/models/config_settings.py
@@ -26,11 +26,11 @@ class ClouderConfigSettings(models.Model):
         'clouder.container', 'Salt Master', readonly=True)
     runner = fields.Selection(
         lambda s: s._get_runners(),
-        string='Runner', required=True, default='swarm')
+        required=True, default='swarm')
     runner_id = fields.Many2one('clouder.container', 'Runner')
     executor = fields.Selection(
         lambda s: s._get_executors(),
-        string='Executor', required=True, default='ssh')
+        required=True, default='ssh')
     compose = fields.Boolean('Compose? (Experimental)', default=False)
     end_reset_keys = fields.Datetime('Last Reset Keys ended at')
     end_save_all = fields.Datetime('Last Save All ended at')

--- a/clouder/models/container.py
+++ b/clouder/models/container.py
@@ -1376,7 +1376,7 @@ class ClouderContainer(models.Model):
             # If not compose, purge current container
             if not self.compose:
                 self.stop()
-                self.purge_salt()
+                # self.purge_salt()
                 self.hook_purge_one()
         super(ClouderContainer, self).purge()
 

--- a/clouder/models/container.py
+++ b/clouder/models/container.py
@@ -933,7 +933,7 @@ class ClouderContainer(models.Model):
             child_vals = child[2]
             child_vals.update({'container_id': self.id})
             self.env['clouder.container.child'].create(child_vals)
-        for link in self.env.context.get('container_links', [])
+        for link in self.env.context.get('container_links', []):
             link_vals = link[2]
             link_vals.update({'container_id': self.id})
             self.env['clouder.container.link'].create(link_vals)

--- a/clouder/models/container.py
+++ b/clouder/models/container.py
@@ -1254,7 +1254,7 @@ class ClouderContainer(models.Model):
             for link in service['links']:
                 if link['name'] in services:
                     link['name'] = services[link['name']]['compose_name']
-                links.append(link['name'] + ':' + link['code'])
+                links.append('%s:%s' % (link['name'], link['code']))
             service['links'] = links
 
             volumes_from = []

--- a/clouder/models/container.py
+++ b/clouder/models/container.py
@@ -929,16 +929,14 @@ class ClouderContainer(models.Model):
                 vals['parent_id']).write({'child_id': self.id})
 
         # Deploy links and childs stored in context
-        if 'container_childs' in self.env.context:
-            for child in self.env.context['container_childs']:
-                child_vals = child[2]
-                child_vals.update({'container_id': self.id})
-                self.env['clouder.container.child'].create(child_vals)
-        if 'container_links' in self.env.context:
-            for link in self.env.context['container_links']:
-                link_vals = link[2]
-                link_vals.update({'container_id': self.id})
-                self.env['clouder.container.link'].create(link_vals)
+        for child in self.env.context.get('container_childs', []):
+            child_vals = child[2]
+            child_vals.update({'container_id': self.id})
+            self.env['clouder.container.child'].create(child_vals)
+        for link in self.env.context.get('container_links', [])
+            link_vals = link[2]
+            link_vals.update({'container_id': self.id})
+            self.env['clouder.container.link'].create(link_vals)
         self = self.with_context(container_childs=[], container_links=[])
 
         # Refresh self with added one2many

--- a/clouder/models/container_volume.py
+++ b/clouder/models/container_volume.py
@@ -21,7 +21,8 @@ class ClouderContainerVolume(models.Model):
 
     container_id = fields.Many2one(
         'clouder.container', 'Container', ondelete="cascade", required=True)
-    name = fields.Char('Path', required=True)
+    name = fields.Char('Name', required=True)
+    localpath = fields.Char('Local Path', required=True)
     hostpath = fields.Char('Host path')
     user = fields.Char('System User')
     readonly = fields.Boolean('Readonly?')

--- a/clouder/models/image_volume.py
+++ b/clouder/models/image_volume.py
@@ -32,7 +32,8 @@ class ClouderImageVolume(models.Model):
         'clouder.image', 'Image', ondelete="cascade", required=False)
     template_id = fields.Many2one(
         'clouder.image.template', 'Template', ondelete="cascade")
-    name = fields.Char('Path', required=True)
+    name = fields.Char('Name', required=True)
+    localpath = fields.Char('Local Path', required=True)
     hostpath = fields.Char('Host path')
     user = fields.Char('System User')
     readonly = fields.Boolean('Readonly?')

--- a/clouder/models/image_volume.py
+++ b/clouder/models/image_volume.py
@@ -26,7 +26,7 @@ class ClouderImageVolume(models.Model):
 
     _template_parent_model = 'clouder.image'
     _template_parent_many2one = 'image_id'
-    _template_fields = ['hostpath', 'user', 'readonly', 'nosave']
+    _template_fields = ['localpath', 'hostpath', 'user', 'readonly', 'nosave']
 
     image_id = fields.Many2one(
         'clouder.image', 'Image', ondelete="cascade", required=False)

--- a/clouder/models/model.py
+++ b/clouder/models/model.py
@@ -591,7 +591,7 @@ class ClouderModel(models.AbstractModel):
                 cmd_temp.append(cmd_arg)
             cmd = cmd_temp
             cmd.append('"')
-            cmd.insert(0, container + ' ' + executor + ' -c ')
+            cmd.insert(0, '%s %s -c ' % (container, executor))
             if username:
                 cmd.insert(0, '-u ' + username)
             cmd.insert(0, 'docker exec')

--- a/clouder/models/model.py
+++ b/clouder/models/model.py
@@ -573,6 +573,14 @@ class ClouderModel(models.AbstractModel):
             cmd.insert(0, 'cd ' + path + ';')
 
         if self._name == 'clouder.container':
+
+            container = self.name
+            if self.runner == 'swarm':
+                # Replace container name by name if the
+                # first pod running this service
+                container = "$(docker ps --format={{.Names}} | grep " + \
+                            container + ". | awk {'print $1'})"
+
             cmd_temp = []
             first = True
             for cmd_arg in cmd:
@@ -583,11 +591,12 @@ class ClouderModel(models.AbstractModel):
                 cmd_temp.append(cmd_arg)
             cmd = cmd_temp
             cmd.append('"')
-            cmd.insert(0, self.name + ' ' + executor + ' -c ')
+            cmd.insert(0, container + ' ' + executor + ' -c ')
             if username:
                 cmd.insert(0, '-u ' + username)
             cmd.insert(0, 'docker exec')
 
+        self.log('')
         self.log('host : ' + host)
         self.log('command : ' + ' '.join(cmd))
         cmd = [c.replace('$$$', '') for c in cmd]

--- a/clouder/models/model.py
+++ b/clouder/models/model.py
@@ -69,6 +69,34 @@ class ClouderModel(models.AbstractModel):
         return self.env.ref('clouder.clouder_settings').email_sysadmin
 
     @property
+    def master_id(self):
+        """
+        Property returning the deployer of the clouder.
+        """
+        return self.env.ref('clouder.clouder_settings').master_id
+
+    @property
+    def runner(self):
+        """
+        Property returning the runner of the clouder.
+        """
+        return self.env.ref('clouder.clouder_settings').runner
+
+    @property
+    def executor(self):
+        """
+        Property returning the executor of the clouder.
+        """
+        return self.env.ref('clouder.clouder_settings').executor
+
+    @property
+    def compose(self):
+        """
+        Property returning the compose of the clouder.
+        """
+        return self.env.ref('clouder.clouder_settings').compose
+
+    @property
     def salt_master(self):
         """
         Property returning the salt master of the clouder.
@@ -391,6 +419,12 @@ class ClouderModel(models.AbstractModel):
         """
 
         res = super(ClouderModel, self).create(vals)
+
+        # Make sure one2one relation with
+        # parent link is immediately established
+        if self._name == 'clouder.container' and 'parent_id' in vals:
+            self.env['clouder.container.child'].browse(
+                vals['parent_id']).write({'child_id': res.id})
 
         if self._autodeploy:
             res.hook_create()

--- a/clouder/models/model.py
+++ b/clouder/models/model.py
@@ -354,6 +354,7 @@ class ClouderModel(models.AbstractModel):
 
     @api.multi
     def deploy_frame(self):
+        self.ensure_one()
         try:
             self.deploy()
             self.deploy_links()
@@ -368,6 +369,7 @@ class ClouderModel(models.AbstractModel):
         Hook which can be used by inheriting objects to execute actions when
         we create a new record.
         """
+        self.ensure_one()
         self.purge()
         return
 
@@ -377,6 +379,7 @@ class ClouderModel(models.AbstractModel):
         Hook which can be used by inheriting objects to execute actions when
         we delete a record.
         """
+        self.ensure_one()
         self.purge_links()
         return
 
@@ -385,6 +388,7 @@ class ClouderModel(models.AbstractModel):
         """
         Force deployment of all links linked to a record.
         """
+        self.ensure_one()
         if hasattr(self, 'link_ids'):
             for link in self.link_ids:
                 link.deploy_()
@@ -394,6 +398,7 @@ class ClouderModel(models.AbstractModel):
         """
         Force purge of all links linked to a record.
         """
+        self.ensure_one()
         if hasattr(self, 'link_ids'):
             for link in self.link_ids:
                 link.purge_()
@@ -403,10 +408,12 @@ class ClouderModel(models.AbstractModel):
         """"
         Action which purge then redeploy a record.
         """
+        self.ensure_one()
         self.do('reinstall', 'deploy_frame')
 
     @api.multi
     def hook_create(self, vals):
+        self.ensure_one()
         return
 
     @api.model
@@ -452,6 +459,8 @@ class ClouderModel(models.AbstractModel):
         :param port: The port we need to connect.
         :param username: The username we need to connect.
         """
+
+        self.ensure_one()
 
         server = self
         if self._name == 'clouder.container':
@@ -552,6 +561,8 @@ class ClouderModel(models.AbstractModel):
         :param stdin_arg: The command we need to execute in stdin.
         :param path: The path where the command need to be executed.
         """
+
+        self.ensure_one()
 
         if self._name == 'clouder.container' \
                 and self.childs and 'exec' in self.childs:
@@ -659,6 +670,8 @@ class ClouderModel(models.AbstractModel):
         :param destination: The path we need to send the file.
         """
 
+        self.ensure_one()
+
         if self._name == 'clouder.container' and self.childs \
                 and 'exec' in self.childs:
             return self.childs['exec'].get(source, destination, ssh=ssh)
@@ -686,6 +699,8 @@ class ClouderModel(models.AbstractModel):
         :param source: The path we need to get the file.
         :param destination: The path we need to send the file.
         """
+
+        self.ensure_one()
 
         if self._name == 'clouder.container' and self.childs \
                 and 'exec' in self.childs:

--- a/clouder/models/save.py
+++ b/clouder/models/save.py
@@ -283,7 +283,7 @@ class ClouderSave(models.Model):
         if self.base_fullname:
             container.server_id.execute([
                 'docker', 'cp',
-                '%s:%s' % (container.name, backup_dir),
+                '%s:%s' % (container.pod, backup_dir),
                 self.get_directory_clouder(),
             ])
         else:
@@ -292,7 +292,7 @@ class ClouderSave(models.Model):
                     'mkdir', '-p', os.path.join(directory, volume),
                 ])
                 container.server_id.execute([
-                    'docker', 'cp', '%s:%s' % (container.name, volume),
+                    'docker', 'cp', '%s:%s' % (container.pod, volume),
                     os.path.join(directory, os.path.split(volume)[0]),
                 ])
 

--- a/clouder/models/server.py
+++ b/clouder/models/server.py
@@ -256,6 +256,7 @@ class ClouderServer(models.Model):
         res = super(ClouderServer, self).create(vals)
         # In swarm mode, set master node with current node if not already exist
         if self.runner == 'swarm' and not self.master_id:
+            self.write({'manager': True})
             self.env.ref('clouder.clouder_settings').master_id = res.id
         return res
 
@@ -314,9 +315,6 @@ class ClouderServer(models.Model):
         """
         """
         self.deploy_ssh_config()
-        if self.deployer == 'swarm' and self.master_id == self:
-            self.execute(
-                ['docker', 'swarm', 'init', '--advertise-addr', self.ip])
         super(ClouderServer, self).deploy()
 
     @api.multi

--- a/clouder/tools.py
+++ b/clouder/tools.py
@@ -6,7 +6,7 @@ import string
 from random import SystemRandom
 
 
-def generate_random_password(size, punctuation=True):
+def generate_random_password(size, punctuation=False):
     """ Method which can be used to generate a random password.
 
     :param size: (int) The size of the random string to generate

--- a/clouder/view.xml
+++ b/clouder/view.xml
@@ -339,6 +339,7 @@
                         <field name="environment_id"/>
                         <field name="login" attrs="{'invisible':[('runner_id','!=',False)]}"/>
                         <field name="ssh_port" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
+                        <field name="manager"/>
                         <field name="provider_id"/>
                         <newline/>
                         <field name="private_key" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
@@ -990,10 +991,14 @@
                 <form string="Application" version="7.0">
                     <group col="4">
                         <field name="email_sysadmin" required="1"/>
+                        <newline/>
+                        <field name="master_id"/>
                         <field name="salt_master_id"/>
-                        <field name="deployer"/>
+                        <field name="runner"/>
+                        <field name="runner_id" attrs="{'invisible': [('deployer','!=','custom')], 'required=': [('deployer','!=','custom')]}"/>
+                        <newline/>
+                        <field name="compose"/>
                         <field name="executor"/>
-                        <field name="runner_id" attrs="{'invisible': [('deployer','!=','runner')], 'required=': [('deployer','!=','runner')]}"/>
                         <newline/>
                         <field name="end_save_all"/>
                         <field name="end_update_containers"/>

--- a/clouder/view.xml
+++ b/clouder/view.xml
@@ -337,10 +337,11 @@
                     <group col="4">
                         <field name="name"/>
                         <field name="domain_id"/>
-                        <field name="ip" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
-                        <field name="environment_id"/>
+                        <field name="public_ip" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
+                        <field name="private_ip" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
                         <field name="login" attrs="{'invisible':[('runner_id','!=',False)]}"/>
                         <field name="ssh_port" attrs="{'invisible':[('runner_id','!=',False)], 'required':[('runner_id','=',False)]}"/>
+                        <field name="environment_id"/>
                         <field name="manager"/>
                         <field name="provider_id"/>
                         <newline/>
@@ -384,7 +385,8 @@
                     <field name="name"/>
                     <field name="domain_id"/>
                     <field name="runner_id"/>
-                    <field name="ip"/>
+                    <field name="public_ip"/>
+                    <field name="private_ip"/>
                     <field name="ssh_port"/>
                 </tree>
             </field>

--- a/clouder/view.xml
+++ b/clouder/view.xml
@@ -195,6 +195,7 @@
                         <newline/>
                         <field name="volumes_from_ids" widget="many2many_tags"/>
                         <field name="public"/>
+                        <field name="scale"/>
                         <field name="from_id" attrs="{'invisible': [('from_id','=', False)]}"/>
                         <field name="dummy"/>
                         <field name="provider_id" attrs="{'invisible': [('dummy','=', False)], 'required': [('dummy', '=', True)]}"/>
@@ -220,6 +221,7 @@
                             <field name="volume_ids" colspan="4" attrs="{'invisible': [('child_ids','!=', [])]}">
                                 <tree string="Volumes" editable="bottom">
                                     <field name="name"/>
+                                    <field name="localpath"/>
                                     <field name="hostpath"/>
                                     <field name="user"/>
                                     <field name="readonly"/>
@@ -823,6 +825,7 @@
                     <field name="volume_ids" colspan="4">
                         <tree string="Volumes" editable="bottom">
                             <field name="name"/>
+                            <field name="localpath"/>
                             <field name="hostpath"/>
                             <field name="user"/>
                             <field name="readonly"/>
@@ -878,6 +881,7 @@
                     <field name="volume_ids" colspan="4">
                         <tree string="Volumes" editable="bottom">
                             <field name="name"/>
+                            <field name="localpath"/>
                             <field name="hostpath"/>
                             <field name="user"/>
                             <field name="readonly"/>
@@ -995,7 +999,7 @@
                         <field name="master_id"/>
                         <field name="salt_master_id"/>
                         <field name="runner"/>
-                        <field name="runner_id" attrs="{'invisible': [('deployer','!=','custom')], 'required=': [('deployer','!=','custom')]}"/>
+                        <field name="runner_id" attrs="{'invisible': [('runner','!=','custom')], 'required=': [('runner','!=','custom')]}"/>
                         <newline/>
                         <field name="compose"/>
                         <field name="executor"/>

--- a/clouder_asynchronous/clouder_asynchronous.py
+++ b/clouder_asynchronous/clouder_asynchronous.py
@@ -62,6 +62,7 @@ def connector_enqueue(
     job.search([('state', '=', 'failed')]).write({'state': 'pending'})
     return res
 
+
 # Add function in connector whitelist
 whitelist_unpickle_global(copy_reg._reconstructor)
 whitelist_unpickle_global(tools.misc.frozendict)

--- a/clouder_runner_kubernetes/template.xml
+++ b/clouder_runner_kubernetes/template.xml
@@ -11,7 +11,8 @@
         </record>
        <record id="image_template_kubernetes_volume_docker" model="clouder.image.volume">
             <field name="template_id" ref="image_template_kubernetes"/>
-            <field name="name">/var/run/docker.sock</field>
+            <field name="name">docker</field>
+            <field name="localpath">/var/run/docker.sock</field>
             <field name="hostpath">/var/run/docker.sock</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>

--- a/clouder_runner_openshift/template.xml
+++ b/clouder_runner_openshift/template.xml
@@ -16,33 +16,38 @@
         </record>
         <record id="image_openshift_volume_rootfs" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
-            <field name="name">/rootfs</field>
+            <field name="name">rootfs</field>
+            <field name="localpath">/rootfs</field>
             <field name="hostpath">/</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>
         </record>
-        <record id="image_openshift_volume_ver_run" model="clouder.image.volume">
+        <record id="image_openshift_volume_var_run" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
-            <field name="name">/var/run</field>
+            <field name="name">var_run</field>
+            <field name="localpath">/var/run</field>
             <field name="hostpath">/var/run</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_openshift_volume_sys" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
-            <field name="name">/sys</field>
+            <field name="name">sys</field>
+            <field name="localpath">/sys</field>
             <field name="hostpath">/sys</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_openshift_volume_docker" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
-            <field name="name">/var/lib/docker</field>
+            <field name="name">docker</field>
+            <field name="localpath">/var/lib/docker</field>
             <field name="hostpath">/var/lib/docker</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_openshift_volume_openshift_volumes" model="clouder.image.volume">
             <field name="image_id" ref="image_openshift"/>
-            <field name="name">/var/lib/openshift/openshift.local.volumes</field>
+            <field name="name">openshift_volumes</field>
+            <field name="localpath">/var/lib/openshift/openshift.local.volumes</field>
             <field name="hostpath">/var/lib/openshift/openshift.local.volumes</field>
             <field name="nosave" eval="True"/>
         </record>

--- a/clouder_template_bind/bind.xml
+++ b/clouder_template_bind/bind.xml
@@ -20,7 +20,8 @@
         </record>
         <record id="image_template_bind_data_volume_bind" model="clouder.image.volume">
             <field name="template_id" ref="image_template_bind_data"/>
-            <field name="name">/etc/bind</field>
+            <field name="name">bind</field>
+            <field name="localpath">/etc/bind</field>
         </record>
         <record id="image_bind_data" model="clouder.image">
             <field name="name">image_bind_data</field>

--- a/clouder_template_drupal/template.xml
+++ b/clouder_template_drupal/template.xml
@@ -47,11 +47,13 @@
         </record>
         <record id="image_drupal_volume_www" model="clouder.image.volume">
             <field name="image_id" ref="image_drupal"/>
-            <field name="name">/var/www</field>
+            <field name="name">www</field>
+            <field name="localpath">/var/www</field>
         </record>
         <record id="image_drupal_volume_etc" model="clouder.image.volume">
             <field name="image_id" ref="image_drupal"/>
-            <field name="name">/etc/nginx</field>
+            <field name="name">etc</field>
+            <field name="localpath">/etc/nginx</field>
         </record>
         <record id="image_drupal_port_http" model="clouder.image.port">
             <field name="image_id" ref="image_drupal"/>

--- a/clouder_template_gitlab/__openerp__.py
+++ b/clouder_template_gitlab/__openerp__.py
@@ -25,6 +25,7 @@
     'version': '9.0.10.0.0',
     'category': 'Clouder',
     'depends': [
+        'clouder',
         'clouder_template_bind',
         'clouder_template_shinken',
         'clouder_template_postfix',

--- a/clouder_template_gitlab/template_gitlab.xml
+++ b/clouder_template_gitlab/template_gitlab.xml
@@ -32,27 +32,33 @@
         </record>
         <record id="image_template_gitlab_data_volume_home" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/home/git</field>
+            <field name="name">/home</field>
+            <field name="localpath">/home/git</field>
         </record>
         <record id="image_template_gitlab_data_volume_nginx" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/etc/nginx</field>
+            <field name="name">nginx</field>
+            <field name="localpath">/etc/nginx</field>
         </record>
         <record id="image_template_gitlab_data_volume_logrotate" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/etc/logrotate</field>
+            <field name="name">logrotate</field>
+            <field name="localpath">/etc/logrotate</field>
         </record>
         <record id="image_template_gitlab_data_volume_data" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/opt/gitlab/data</field>
+            <field name="name">data</field>
+            <field name="localpath">/opt/gitlab/data</field>
         </record>
         <record id="image_template_gitlab_data_volume_config" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/opt/gitlab/config</field>
+            <field name="name">config</field>
+            <field name="localpath">/opt/gitlab/config</field>
         </record>
         <record id="image_template_gitlab_data_volume_var" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_data"/>
-            <field name="name">/opt/gitlab/var</field>
+            <field name="name">var</field>
+            <field name="localpath">/opt/gitlab/var</field>
         </record>
 
         <record id="image_template_gitlab_files" model="clouder.image.template">
@@ -60,12 +66,14 @@
         </record>
         <record id="image_template_gitlab_files_volume_files" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_files"/>
-            <field name="name">/opt/gitlab/files</field>
+            <field name="name">files</field>
+            <field name="localpath">/opt/gitlab/files</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_template_gitlab_files_volume_workhorse" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlab_files"/>
-            <field name="name">/opt/gitlab/gitlab-workhorse</field>
+            <field name="name">workhorse</field>
+            <field name="localpath">/opt/gitlab/gitlab-workhorse</field>
             <field name="nosave" eval="True"/>
         </record>
 

--- a/clouder_template_gitlab/template_gitlabci.xml
+++ b/clouder_template_gitlab/template_gitlabci.xml
@@ -21,7 +21,8 @@
         </record>
         <record id="image_template_gitlabci_volume_docker" model="clouder.image.volume">
             <field name="template_id" ref="image_template_gitlabci"/>
-            <field name="name">/var/run/docker.sock</field>
+            <field name="name">docker</field>
+            <field name="localpath">/var/run/docker.sock</field>
             <field name="hostpath">/var/run/docker.sock</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>

--- a/clouder_template_magento/template.xml
+++ b/clouder_template_magento/template.xml
@@ -123,24 +123,29 @@
         </record>
         <record id="image_magento_data_volume_logs" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
-            <field name="name">/opt/magento/exec/var/log</field>
+            <field name="name">logs</field>
+            <field name="localpath">/opt/magento/exec/var/log</field>
         </record>
         <record id="image_magento_data_volume_etc" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
-            <field name="name">/opt/magento/exec/app/etc</field>
+            <field name="name">etc</field>
+            <field name="localpath">/opt/magento/exec/app/etc</field>
         </record>
         <record id="image_magento_data_volume_local_modules" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
-            <field name="name">/opt/magento/exec/app/code/local</field>
+            <field name="name">local</field>
+            <field name="localpath">/opt/magento/exec/app/code/local</field>
         </record>
         <record id="image_magento_data_volume_config" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
-            <field name="name">/opt/magento/config</field>
+            <field name="name">config</field>
+            <field name="localpath">/opt/magento/config</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_data_volume_sites_enabled" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_data"/>
-            <field name="name">/etc/apache2/sites-enabled</field>
+            <field name="name">sites-enabled</field>
+            <field name="localpath">/etc/apache2/sites-enabled</field>
         </record>
 
         <record id="image_magento_files1_9" model="clouder.image">
@@ -153,7 +158,8 @@
         </record>
         <record id="image_magento_files1_9_volume_files" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_files1_9"/>
-            <field name="name">/opt/magento/files</field>
+            <field name="name">files</field>
+            <field name="localpath">/opt/magento/files</field>
             <field name="nosave" eval="True"/>
         </record>
 
@@ -168,31 +174,36 @@
         <record id="image_magento_exec_volume_logs" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
             <field name="from_code">data</field>
-            <field name="name">/opt/magento/exec/var/log</field>
+            <field name="name">log</field>
+            <field name="localpath">/opt/magento/exec/var/log</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_config" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
             <field name="from_code">data</field>
-            <field name="name">/opt/magento/exec/app/etc</field>
+            <field name="name">config</field>
+            <field name="localpath">/opt/magento/exec/app/etc</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_local_modules" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
             <field name="from_code">data</field>
-            <field name="name">/opt/magento/exec/app/code/local</field>
+            <field name="name">local</field>
+            <field name="localpath">/opt/magento/exec/app/code/local</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_sites_enabled" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
             <field name="from_code">data</field>
-            <field name="name">/etc/apache2/sites-enabled</field>
+            <field name="name">sites-enabled</field>
+            <field name="localpath">/etc/apache2/sites-enabled</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_volume_files" model="clouder.image.volume">
             <field name="image_id" ref="image_magento_exec"/>
             <field name="from_code">files</field>
-            <field name="name">/opt/magento/files</field>
+            <field name="name">files</field>
+            <field name="localpath">/opt/magento/files</field>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_magento_exec_port_web" model="clouder.image.port">

--- a/clouder_template_mysql/template.xml
+++ b/clouder_template_mysql/template.xml
@@ -34,12 +34,14 @@
         </record>
         <record id="image_template_mysql_data_volume_etc" model="clouder.image.volume">
             <field name="template_id" ref="image_template_mysql_data"/>
-            <field name="name">/etc/mysql</field>
+            <field name="name">etc</field>
+            <field name="localpath">/etc/mysql</field>
             <field name="user">mysql</field>
         </record>
         <record id="image_template_mysql_data_volume_var" model="clouder.image.volume">
             <field name="template_id" ref="image_template_mysql_data"/>
-            <field name="name">/var/lib/mysql</field>
+            <field name="name">var</field>
+            <field name="localpath">/var/lib/mysql</field>
             <field name="user">mysql</field>
         </record>
         <record id="image_mysql_data" model="clouder.image">

--- a/clouder_template_odoo/template.xml
+++ b/clouder_template_odoo/template.xml
@@ -78,23 +78,28 @@
         </record>
         <record id="image_template_odoo_data_volume_home" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_data"/>
-            <field name="name">/home/odoo</field>
+            <field name="name">home</field>
+            <field name="localpath">/home/odoo</field>
         </record>
         <record id="image_template_odoo_data_volume_data" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_data"/>
-            <field name="name">/opt/odoo/data</field>
+            <field name="name">data</field>
+            <field name="localpath">/opt/odoo/data</field>
         </record>
         <record id="image_template_odoo_data_volume_etc" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_data"/>
-            <field name="name">/opt/odoo/etc</field>
+            <field name="name">etc</field>
+            <field name="localpath">/opt/odoo/etc</field>
         </record>
         <record id="image_template_odoo_data_volume_extra_addons" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_data"/>
-            <field name="name">/opt/odoo/extra-addons</field>
+            <field name="name">extra-addons</field>
+            <field name="localpath">/opt/odoo/extra-addons</field>
         </record>
         <record id="image_template_odoo_data_volume_var" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_data"/>
-            <field name="name">/opt/odoo/var</field>
+            <field name="name">var</field>
+            <field name="localpath">/opt/odoo/var</field>
         </record>
 
         <record id="image_template_odoo_files" model="clouder.image.template">
@@ -102,7 +107,8 @@
         </record>
         <record id="image_template_odoo_data_volume_files" model="clouder.image.volume">
             <field name="template_id" ref="image_template_odoo_files"/>
-            <field name="name">/opt/odoo/files</field>
+            <field name="name">files</field>
+            <field name="localpath">/opt/odoo/files</field>
             <field name="nosave" eval="True"/>
         </record>
 

--- a/clouder_template_piwik/template.xml
+++ b/clouder_template_piwik/template.xml
@@ -25,19 +25,22 @@
         </record>
         <record id="image_piwik_volume_versions" model="clouder.image.volume">
             <field name="image_id" ref="image_piwik"/>
-            <field name="name">/opt/versions</field>
+            <field name="name">versions</field>
+            <field name="localpath">/opt/versions</field>
             <field name="hostpath">/opt/services</field>
             <field name="readonly" eval="True"/>
             <field name="nosave" eval="True"/>
         </record>
         <record id="image_piwik_volume_www" model="clouder.image.volume">
             <field name="image_id" ref="image_piwik"/>
-            <field name="name">/var/www</field>
+            <field name="name">www</field>
+            <field name="localpath">/var/www</field>
             <field name="user">www-data</field>
         </record>
         <record id="image_piwik_volume_etc" model="clouder.image.volume">
             <field name="image_id" ref="image_piwik"/>
-            <field name="name">/etc/nginx</field>
+            <field name="name">etc</field>
+            <field name="localpath">/etc/nginx</field>
         </record>
         <record id="image_piwik_port_ssh" model="clouder.image.port">
             <field name="image_id" ref="image_piwik"/>

--- a/clouder_template_postfix/res/openerp_mailgate.py
+++ b/clouder_template_postfix/res/openerp_mailgate.py
@@ -51,6 +51,7 @@ class DefaultConfig(object):
     MAIL_SERVER_PORT = 25
     MAIL_ADMINS = ('info@example.com',)
 
+
 config = DefaultConfig()
 
 
@@ -212,6 +213,7 @@ def main():
         sys.stderr.write(
             "Failed to deliver email to Odoo Server, "
             "sending error notification to %s\n" % config.MAIL_ADMINS)
+
 
 if __name__ == '__main__':
     main()

--- a/clouder_template_postfix/template.xml
+++ b/clouder_template_postfix/template.xml
@@ -12,7 +12,8 @@
         </record>
         <record id="image_template_spamassassin_volume_spamassassin" model="clouder.image.volume">
             <field name="template_id" ref="image_template_spamassassin"/>
-            <field name="name">/etc/spamassassin</field>
+            <field name="name">spamassassin</field>
+            <field name="localpath">/etc/spamassassin</field>
         </record>
         <record id="image_template_spamassassin_port_spamd" model="clouder.image.port">
             <field name="template_id" ref="image_template_spamassassin"/>
@@ -71,11 +72,13 @@
         </record>
         <record id="image_template_postfix_data_volume_postfix" model="clouder.image.volume">
             <field name="template_id" ref="image_template_postfix_data"/>
-            <field name="name">/etc/postfix</field>
+            <field name="name">postfix</field>
+            <field name="localpath">/etc/postfix</field>
         </record>
         <record id="image_template_postfix_data_volume_aliases" model="clouder.image.volume">
             <field name="template_id" ref="image_template_postfix_data"/>
-            <field name="name">/etc/aliases-dir</field>
+            <field name="name">aliases-dir</field>
+            <field name="localpath">/etc/aliases-dir</field>
         </record>
         <record id="image_postfix_data" model="clouder.image">
             <field name="name">image_postfix_data</field>

--- a/clouder_template_postgres/template.xml
+++ b/clouder_template_postgres/template.xml
@@ -26,17 +26,20 @@
         </record>
         <record id="image_template_postgres_data_volume_etc" model="clouder.image.volume">
             <field name="template_id" ref="image_template_postgres_data"/>
-            <field name="name">/etc/postgresql</field>
+            <field name="name">etc</field>
+            <field name="localpath">/etc/postgresql</field>
             <field name="user">postgres</field>
         </record>
         <record id="image_template_postgres_data_volume_log" model="clouder.image.volume">
             <field name="template_id" ref="image_template_postgres_data"/>
-            <field name="name">/var/log/postgresql</field>
+            <field name="name">log</field>
+            <field name="localpath">/var/log/postgresql</field>
             <field name="user">postgres</field>
         </record>
         <record id="image_template_postgres_data_volume_lib" model="clouder.image.volume">
             <field name="template_id" ref="image_template_postgres_data"/>
-            <field name="name">/var/lib/postgresql</field>
+            <field name="name">lib</field>
+            <field name="localpath">/var/lib/postgresql</field>
             <field name="user">postgres</field>
         </record>
         <record id="image_postgres_data" model="clouder.image">

--- a/clouder_template_redis/template.xml
+++ b/clouder_template_redis/template.xml
@@ -12,7 +12,8 @@
         </record>
         <record id ="image_template_redis_data_volume_data" model="clouder.image.volume">
             <field name="template_id" ref="image_template_redis_data"/>
-            <field name="name">/data</field>
+            <field name="name">data</field>
+            <field name="localpath">/data</field>
             <field name="user">redis</field>
         </record>
         <record id="image_redis_data" model="clouder.image">

--- a/clouder_template_shinken/template.xml
+++ b/clouder_template_shinken/template.xml
@@ -13,7 +13,8 @@
         </record>
         <record id="image_template_shinken_data_volume_shinken" model="clouder.image.volume">
             <field name="template_id" ref="image_template_shinken_data"/>
-            <field name="name">/usr/local/shinken/etc</field>
+            <field name="name">shinken</field>
+            <field name="localpath">/usr/local/shinken/etc</field>
             <field name="user">shinken</field>
         </record>
         <record id="image_shinken_data" model="clouder.image">
@@ -89,6 +90,7 @@
             <field name="base" eval="True"/>
         </record>
 
+        <!--
         <record id="clouder.application_salt_minion" model="clouder.application">
             <field name="template_ids" eval="[(4, [ref('application_template_container_shinken')])]"/>
         </record>
@@ -101,6 +103,7 @@
         <record id="clouder_template_proxy.application_proxy_data" model="clouder.application">
             <field name="template_ids" eval="[(4, [ref('application_template_container_shinken')])]"/>
         </record>
+        -->
 
     </data>
 </openerp>


### PR DESCRIPTION
First work for Docker Compose and Docker Swarm. I managed to deploy with it the container Salt Master, but I still have to make a debug on the whole oneclick.

The support for Docker Compose is only experimental because it currently not work yet with Docker Swarm. Still I made a first work for it because of all the challenges it implies to manage this concept (Currently Engine and Swarm deploy containers one by one at the deepest level, while a Compose deployment require a deployment at the upper level) and I'm quite proud of it, should not worry too much for the future now.
Also Salt is deactivated for now until we need it, want to focus on Swarm debug and Salt has no plugin for Swarm yet.

The default Clouder setup will become Swarm/No Compose/SSH. In the end (when Docker and Salt will allow it), the default setup shall become Swarm/Compose/Salt but for now the other setup shall do it.